### PR TITLE
fix: fix yarn check errors

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
-nodeLinker: pnp
+nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.0.2.cjs

--- a/src/lib/components/game/FlappyBird.svelte
+++ b/src/lib/components/game/FlappyBird.svelte
@@ -66,6 +66,13 @@
 		}
 	}
 
+	function handleCanvasKeydown(event: KeyboardEvent): void {
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			handleCanvasClick();
+		}
+	}
+
 	onMount(() => {
 		unsubscribe = keyboardManager.addHandler(handleKeyboard);
 		if (typeof window !== 'undefined') {
@@ -104,8 +111,14 @@
 						<span class="score-label">BEST: <span class="score-value">{best}</span></span>
 					</div>
 
-					<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-					<div class="canvas-wrapper" onclick={handleCanvasClick} role="application" aria-label="Game area - click or press space to jump">
+					<div
+						class="canvas-wrapper"
+						role="button"
+						tabindex="0"
+						aria-label="Game area - click or press space to jump"
+						onclick={handleCanvasClick}
+						onkeydown={handleCanvasKeydown}
+					>
 						<GameCanvas />
 
 						{#if state === 'idle'}

--- a/src/lib/components/playground/ResponseViewer.svelte
+++ b/src/lib/components/playground/ResponseViewer.svelte
@@ -4,11 +4,11 @@
 	import ResponseVisualizer from './ResponseVisualizer.svelte';
 
 	const response = $derived($lastResponse);
-	const state = $derived($executionState);
+	const executionStateValue = $derived($executionState);
 	const toolId = $derived($selectedToolId);
 
 	// Toggle between raw and visual view
-	let viewMode = $state<'raw' | 'visual'>('visual');
+	let viewMode: 'raw' | 'visual' = $state('visual');
 
 	// Check if current tool supports visualization
 	const supportsVisualization = $derived.by(() => {
@@ -78,7 +78,7 @@
 	</div>
 
 	<div class="response-content">
-		{#if state === 'executing'}
+		{#if executionStateValue === 'executing'}
 			<div class="executing">
 				<span class="spinner"></span>
 				<span>Executing...</span>

--- a/src/lib/components/visualizations/ASCIITimeline.svelte
+++ b/src/lib/components/visualizations/ASCIITimeline.svelte
@@ -132,19 +132,19 @@
 			<span class="entry-count">({displayEntries.length} entries)</span>
 		</div>
 	{/if}
-	<div class="timeline-list" role="list" aria-label={title}>
+	<div class="timeline-list" aria-label={title}>
 		{#if displayEntries.length > 0}
 			{#each displayEntries as entry, index}
-				<!-- svelte-ignore a11y_click_events_have_key_events -->
-				<div
+				<button
+					type="button"
 					class="timeline-entry"
 					class:selected={interactive && index === selectedIndex}
 					class:success={entry.success}
 					class:error={!entry.success}
-					role="listitem"
-					aria-selected={interactive && index === selectedIndex}
+					aria-pressed={interactive && index === selectedIndex}
 					tabindex={interactive && index === selectedIndex ? 0 : -1}
 					onclick={() => handleEntryClick(index)}
+					disabled={!interactive}
 				>
 					<span class="timestamp">[{formatTime(entry.timestamp)}]</span>
 					<span class="tool-name">{entry.toolName}</span>
@@ -154,7 +154,7 @@
 					{#if !entry.success && entry.error}
 						<span class="error-hint" title={entry.error}>({entry.error.slice(0, 30)}{entry.error.length > 30 ? '...' : ''})</span>
 					{/if}
-				</div>
+				</button>
 			{/each}
 		{:else}
 			<div class="empty-state">
@@ -203,6 +203,19 @@
 		white-space: nowrap;
 		cursor: pointer;
 		border-left: 2px solid transparent;
+		background: none;
+		border-top: none;
+		border-right: none;
+		border-bottom: none;
+		width: 100%;
+		text-align: left;
+		font: inherit;
+		color: inherit;
+	}
+
+	.timeline-entry:disabled {
+		cursor: default;
+		opacity: 0.7;
 	}
 
 	.timeline-entry:hover {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -117,7 +117,8 @@
 	}
 
 	.content-area.focused {
-		/* Visual indicator that content is focused */
+		outline: 1px solid var(--border);
+		outline-offset: -1px;
 	}
 
 	.content-area :global(.intro-content) {


### PR DESCRIPTION
.yarnrc.yml: set nodeLinker: node-modules for TypeScript/svelte-check resolution.
ResponseViewer.svelte: renamed the derived execution state to avoid store name collisions and typed viewMode.
FlappyBird.svelte: made the canvas wrapper keyboard-focusable with a key handler and button semantics.
ASCIITimeline.svelte: rendered entries as buttons with proper disabled/pressed semantics and reset button styles.
+page.svelte: added a visible focus outline to content-area.focused.