### PR TITLE
Use shared Shiki highlighter singleton

### DIFF
--- a/src/lib/components/docs/CodeBlock.svelte
+++ b/src/lib/components/docs/CodeBlock.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { getHighlighter, resolveLanguage } from '$lib/utils/shiki';
 
 	interface Props {
 		code: string;
@@ -16,14 +17,11 @@
 
 	async function loadShiki() {
 		try {
-			const { createHighlighter } = await import('shiki');
-			const highlighter = await createHighlighter({
-				themes: ['github-dark'],
-				langs: [language, 'bash', 'json', 'typescript', 'csharp', 'plaintext']
-			});
+			const highlighter = await getHighlighter();
+			const resolvedLanguage = resolveLanguage(language);
 
 			highlightedHtml = highlighter.codeToHtml(code, {
-				lang: language,
+				lang: resolvedLanguage,
 				theme: 'github-dark'
 			});
 			shikiLoaded = true;

--- a/src/lib/utils/shiki.ts
+++ b/src/lib/utils/shiki.ts
@@ -1,0 +1,28 @@
+import type { Highlighter } from 'shiki';
+
+const supportedLanguages = new Set([
+	'bash',
+	'json',
+	'typescript',
+	'csharp',
+	'plaintext'
+]);
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+export function getHighlighter() {
+	if (!highlighterPromise) {
+		highlighterPromise = import('shiki').then(({ createHighlighter }) =>
+			createHighlighter({
+				themes: ['github-dark'],
+				langs: Array.from(supportedLanguages)
+			})
+		);
+	}
+
+	return highlighterPromise;
+}
+
+export function resolveLanguage(language: string) {
+	return supportedLanguages.has(language) ? language : 'plaintext';
+}


### PR DESCRIPTION
### Motivation
- Avoid creating multiple Shiki highlighter instances from each `CodeBlock` which triggers Shiki singleton warnings and wastes resources.
- Cache a single highlighter and normalize languages to improve rendering performance and prevent unsupported-language issues.

### Description
- Add `src/lib/utils/shiki.ts` which exports `getHighlighter()` to lazily create and cache the `shiki` `Highlighter` promise and `resolveLanguage()` to fall back to `plaintext` for unknown languages.
- Update `src/lib/components/docs/CodeBlock.svelte` to call `getHighlighter()` and `resolveLanguage()` instead of invoking `createHighlighter()` per component instance.
- Configure the shared highlighter with the `github-dark` theme and a defined set of supported languages to limit what is loaded.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e72b72ea8832eb04eb90b625cd4f7)