### PR TITLE
Add Google Analytics (G-MQP7KFQ9YD) to Svelte app template

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -38,6 +38,15 @@
 			html[data-theme="total-commander"] { background-color: #fff; }
 		</style>
 
+		<!-- Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-MQP7KFQ9YD"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'G-MQP7KFQ9YD');
+		</script>
+
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
### Motivation
- Enable Google Analytics tracking for the site using measurement ID `G-MQP7KFQ9YD`.
- Ensure the analytics script loads on every page by adding it to the global HTML template.

### Description
- Injected the Google Analytics gtag snippet into `src/app.html` ahead of the ` %sveltekit.head%` placeholder.
- Added the async loader `https://www.googletagmanager.com/gtag/js?id=G-MQP7KFQ9YD` and initialization that creates `dataLayer` and calls `gtag('config', 'G-MQP7KFQ9YD')`.
- The change is a small, static HTML modification to the SvelteKit app template (`src/app.html`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e75c75578832e9a85b4ffe9cdf651)