### PR TITLE
Add mobile navigation drawer and hamburger menu for small screens

### DIFF
--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mobile layout', () => {
+	test.use({ viewport: { width: 390, height: 844 } });
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+	});
+
+	test('should toggle the navigation drawer', async ({ page }) => {
+		const main = page.locator('.tui-main');
+		await expect(main).not.toHaveClass(/mobile-nav-open/);
+
+		await page.locator('button.hamburger-button').click();
+		await expect(main).toHaveClass(/mobile-nav-open/);
+
+		await page.locator('.tui-panel-overlay').click();
+		await expect(main).not.toHaveClass(/mobile-nav-open/);
+	});
+
+	test('should toggle theme from the header on mobile', async ({ page }) => {
+		const html = page.locator('html');
+		await expect(html).toHaveAttribute('data-theme', 'ncurses-dark');
+
+		const themeButton = page.locator('button.theme-indicator');
+		await expect(themeButton).toBeVisible();
+		await expect(page.locator('.theme-toggle')).not.toBeVisible();
+
+		await themeButton.click();
+		await expect(html).toHaveAttribute('data-theme', 'total-commander');
+	});
+
+	test('should hide the footer status bar on mobile', async ({ page }) => {
+		await expect(page.locator('.tui-statusbar')).not.toBeVisible();
+	});
+});

--- a/src/lib/components/tui/TUILayout.svelte
+++ b/src/lib/components/tui/TUILayout.svelte
@@ -4,7 +4,11 @@
 	import TUIMenuBar from './TUIMenuBar.svelte';
 	import TUIStatusBar from './TUIStatusBar.svelte';
 	import { keyboardManager } from '$lib/services/keyboard-manager';
-	import { focusedPanel as focusedPanelStore, togglePanel } from '$stores/keyboard';
+	import {
+		focusedPanel as focusedPanelStore,
+		mobileNavOpen as mobileNavOpenStore,
+		setMobileNavOpen
+	} from '$stores/keyboard';
 
 	interface Props {
 		title?: string;
@@ -25,6 +29,7 @@
 	}: Props = $props();
 
 	const focusedPanel = $derived($focusedPanelStore);
+	const mobileNavOpen = $derived($mobileNavOpenStore);
 
 	// Initialize keyboard manager on mount
 	onMount(() => {
@@ -39,7 +44,7 @@
 <div class="tui-layout">
 	<TUIMenuBar {title} />
 
-	<div class="tui-main">
+	<div class="tui-main" class:mobile-nav-open={mobileNavOpen}>
 		<div
 			class="tui-panel tui-panel-left"
 			class:tui-panel-focused={focusedPanel === 'left'}
@@ -62,6 +67,13 @@
 				<span class="box-br">┘</span>
 			</div>
 		</div>
+
+		<button
+			class="tui-panel-overlay"
+			class:visible={mobileNavOpen}
+			aria-label="Close navigation"
+			onclick={() => setMobileNavOpen(false)}
+		></button>
 
 		<div class="tui-panel-divider">
 			<span class="box-v">│</span>
@@ -111,6 +123,7 @@
 		overflow: hidden;
 		padding: var(--spacing-xs);
 		gap: 0;
+		position: relative;
 	}
 
 	.tui-panel {
@@ -201,5 +214,55 @@
 		display: flex;
 		flex-direction: column;
 		color: var(--border-dim);
+	}
+
+	.tui-panel-overlay {
+		display: none;
+	}
+
+	@media (max-width: 768px) {
+		.tui-main {
+			padding: 0;
+		}
+
+		.tui-panel-left {
+			position: absolute;
+			top: var(--spacing-xs);
+			bottom: var(--spacing-xs);
+			left: var(--spacing-xs);
+			width: min(80vw, 280px);
+			transform: translateX(-120%);
+			transition: transform 0.2s ease;
+			z-index: 3;
+			background-color: var(--bg-primary);
+		}
+
+		.tui-main.mobile-nav-open .tui-panel-left {
+			transform: translateX(0);
+		}
+
+		.tui-panel-right {
+			width: 100%;
+		}
+
+		.tui-panel-overlay {
+			position: absolute;
+			inset: 0;
+			display: block;
+			background: rgba(0, 0, 0, 0.45);
+			border: none;
+			cursor: pointer;
+			opacity: 0;
+			visibility: hidden;
+			pointer-events: none;
+			transition: opacity 0.2s ease;
+			z-index: 2;
+		}
+
+		.tui-panel-overlay.visible {
+			opacity: 1;
+			visibility: visible;
+			pointer-events: auto;
+		}
 	}
 </style>

--- a/src/lib/components/tui/TUIMenuBar.svelte
+++ b/src/lib/components/tui/TUIMenuBar.svelte
@@ -27,7 +27,14 @@
 		<span class="title">{title}</span>
 	</div>
 	<div class="menubar-right">
-		<span class="theme-indicator">[{themeName}]</span>
+		<button
+			class="theme-indicator"
+			onclick={toggleTheme}
+			title="Toggle theme"
+			aria-label="Toggle theme"
+		>
+			[{themeName}]
+		</button>
 		<button class="theme-toggle" onclick={toggleTheme} title="F9 to toggle theme">
 			F9 Theme
 		</button>
@@ -85,8 +92,23 @@
 	}
 
 	.theme-indicator {
+		background: transparent;
+		border: 1px solid transparent;
 		color: var(--text-muted);
 		font-size: var(--font-size-sm);
+		font-family: var(--font-mono);
+		cursor: pointer;
+		padding: var(--spacing-xs) var(--spacing-sm);
+	}
+
+	.theme-indicator:hover {
+		color: var(--menu-fg);
+		border-color: var(--border);
+	}
+
+	.theme-indicator:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 
 	.theme-toggle {
@@ -122,6 +144,10 @@
 
 		.hamburger-button {
 			display: inline-flex;
+		}
+
+		.theme-toggle {
+			display: none;
 		}
 	}
 </style>

--- a/src/lib/components/tui/TUIMenuBar.svelte
+++ b/src/lib/components/tui/TUIMenuBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { theme, toggleTheme, isDarkTheme } from '$stores/theme';
+	import { theme, toggleTheme } from '$stores/theme';
+	import { mobileNavOpen, toggleMobileNav } from '$stores/keyboard';
 
 	interface Props {
 		title?: string;
@@ -9,10 +10,19 @@
 
 	const currentTheme = $derived($theme);
 	const themeName = $derived(currentTheme === 'ncurses-dark' ? 'Dark' : 'Light');
+	const isMobileNavOpen = $derived($mobileNavOpen);
 </script>
 
 <header class="tui-menubar">
 	<div class="menubar-left">
+		<button
+			class="hamburger-button"
+			aria-label="Toggle navigation"
+			aria-expanded={isMobileNavOpen}
+			onclick={toggleMobileNav}
+		>
+			≡
+		</button>
 		<span class="logo">✈</span>
 		<span class="title">{title}</span>
 	</div>
@@ -43,6 +53,20 @@
 		display: flex;
 		align-items: center;
 		gap: var(--spacing-md);
+	}
+
+	.hamburger-button {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		min-width: 44px;
+		min-height: 44px;
+		background: transparent;
+		border: 1px solid var(--border);
+		color: var(--menu-fg);
+		font-size: var(--font-size-lg);
+		cursor: pointer;
+		padding: 0;
 	}
 
 	.logo {
@@ -84,5 +108,20 @@
 	.theme-toggle:focus-visible {
 		outline: 2px solid var(--accent);
 		outline-offset: 2px;
+	}
+
+	@media (max-width: 768px) {
+		.tui-menubar {
+			padding: var(--spacing-xs) var(--spacing-sm);
+		}
+
+		.menubar-left,
+		.menubar-right {
+			gap: var(--spacing-sm);
+		}
+
+		.hamburger-button {
+			display: inline-flex;
+		}
 	}
 </style>

--- a/src/lib/components/tui/TUIStatusBar.svelte
+++ b/src/lib/components/tui/TUIStatusBar.svelte
@@ -144,4 +144,10 @@
 		color: var(--status-fg);
 		padding: var(--spacing-xs) var(--spacing-sm);
 	}
+
+	@media (max-width: 768px) {
+		.tui-statusbar {
+			display: none;
+		}
+	}
 </style>

--- a/src/lib/stores/keyboard.ts
+++ b/src/lib/stores/keyboard.ts
@@ -22,6 +22,9 @@ export const modalOpen = atom<boolean>(false);
 // Current content scroll position
 export const contentScrollTop = atom<number>(0);
 
+// Mobile navigation drawer open state
+export const mobileNavOpen = atom<boolean>(false);
+
 // Derived: is left panel focused
 export const isLeftFocused = computed(focusedPanel, (panel: FocusedPanel) => panel === 'left');
 
@@ -34,6 +37,21 @@ export const isRightFocused = computed(focusedPanel, (panel: FocusedPanel) => pa
 export function togglePanel(): void {
 	if (modalOpen.get()) return;
 	focusedPanel.set(focusedPanel.get() === 'left' ? 'right' : 'left');
+}
+
+/**
+ * Toggle mobile navigation drawer
+ */
+export function toggleMobileNav(): void {
+	if (modalOpen.get()) return;
+	mobileNavOpen.set(!mobileNavOpen.get());
+}
+
+/**
+ * Set mobile navigation drawer state
+ */
+export function setMobileNavOpen(open: boolean): void {
+	mobileNavOpen.set(open);
 }
 
 /**
@@ -131,4 +149,5 @@ export function resetNavigation(): void {
 	expandedSections.set(new Set());
 	modalOpen.set(false);
 	contentScrollTop.set(0);
+	mobileNavOpen.set(false);
 }


### PR DESCRIPTION
### Motivation
- Provide a mobile-friendly navigation experience by exposing the left navigation as a slide-in drawer on small screens.
- Allow toggling the navigation from the top menubar with a touch-friendly hamburger control.
- Keep keyboard/navigation state centralized so the drawer can be controlled from other parts of the app.

### Description
- Add a `mobileNavOpen` atom and helper functions `toggleMobileNav` and `setMobileNavOpen` to `src/lib/stores/keyboard.ts` to track drawer state.
- Add a hamburger button to `src/lib/components/tui/TUIMenuBar.svelte` that calls `toggleMobileNav` and exposes `aria-expanded` for accessibility.
- Update `src/lib/components/tui/TUILayout.svelte` to apply `mobile-nav-open` state, render an overlay button that closes the drawer, and include responsive CSS to turn the left panel into an off-canvas drawer on screens under `768px`.

### Testing
- Ran `yarn test` (Vitest) and all tests passed: 4 test files, 64 tests in total (all passed).
- Ran `yarn check` (Svelte diagnostics) and `svelte-check` reported 0 errors and 0 warnings.
- Performed a headless Playwright smoke run to open a mobile viewport and capture a screenshot of the opened mobile nav, which completed and produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e850c0a50832e9973257fa22275e0)