### PR TITLE
Fix mobile viewport height scrolling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -13,6 +13,7 @@ body {
 	margin: 0;
 	padding: 0;
 	height: 100%;
+	min-height: 100dvh;
 	overflow: hidden;
 }
 

--- a/src/lib/components/tui/TUILayout.svelte
+++ b/src/lib/components/tui/TUILayout.svelte
@@ -109,6 +109,7 @@
 		display: flex;
 		flex-direction: column;
 		height: 100vh;
+		height: 100dvh;
 		width: 100vw;
 		background-color: var(--bg-primary);
 		color: var(--text-primary);


### PR DESCRIPTION
### Motivation
- Mobile Chrome and Safari were clipping vertically long pages so users couldn’t scroll to the bottom.  
- The layout used fixed `100vh` which can be unreliable on mobile browsers due to address bars and dynamic UI.  
- Use modern dynamic viewport units so the app honours the actual visible viewport and avoids clipped content.  

### Description
- Add `min-height: 100dvh` to `html, body` in `src/app.css` to ensure the document respects the dynamic viewport height.  
- Add `height: 100dvh` (alongside the existing `100vh` fallback) to `.tui-layout` in `src/lib/components/tui/TUILayout.svelte` so the main layout uses the dynamic viewport unit on supporting browsers.  
- Preserve `100vh` as a fallback for environments that do not support `dvh`.  

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script that opened `/prompts` at a mobile viewport (`390x844`) and captured a full-page screenshot, which completed successfully.  
- No unit or integration test changes were made and no other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8c89d528832e9a34432ee59cf450)