### PR TITLE
Gate Google Analytics to release builds

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
 		}
 	],
 	webServer: {
-		command: 'yarn build && yarn preview',
+		command: 'VITE_DISABLE_GA=true yarn build && VITE_DISABLE_GA=true yarn preview',
 		url: 'http://localhost:4173',
 		reuseExistingServer: !process.env.CI
 	}

--- a/src/app.html
+++ b/src/app.html
@@ -38,15 +38,6 @@
 			html[data-theme="total-commander"] { background-color: #fff; }
 		</style>
 
-		<!-- Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=G-MQP7KFQ9YD"></script>
-		<script>
-			window.dataLayer = window.dataLayer || [];
-			function gtag(){dataLayer.push(arguments);}
-			gtag('js', new Date());
-			gtag('config', 'G-MQP7KFQ9YD');
-		</script>
-
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { onMount } from 'svelte';
+	import { dev } from '$app/environment';
 	import { theme, applyTheme, type ThemeType } from '$stores/theme';
 	import {
 		initNetworkStatus,
@@ -15,6 +16,7 @@
 	}
 
 	let { children }: Props = $props();
+	const isAnalyticsEnabled = !dev && !import.meta.env.VITE_DISABLE_GA;
 
 	// Apply theme on mount and when it changes
 	onMount(() => {
@@ -44,6 +46,18 @@
 		applyTheme($theme);
 	});
 </script>
+
+{#if isAnalyticsEnabled}
+	<svelte:head>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-MQP7KFQ9YD"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', 'G-MQP7KFQ9YD');
+		</script>
+	</svelte:head>
+{/if}
 
 {@render children()}
 <Toast />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -47,8 +47,8 @@
 	});
 </script>
 
-{#if isAnalyticsEnabled}
-	<svelte:head>
+<svelte:head>
+	{#if isAnalyticsEnabled}
 		<script async src="https://www.googletagmanager.com/gtag/js?id=G-MQP7KFQ9YD"></script>
 		<script>
 			window.dataLayer = window.dataLayer || [];
@@ -56,8 +56,8 @@
 			gtag('js', new Date());
 			gtag('config', 'G-MQP7KFQ9YD');
 		</script>
-	</svelte:head>
-{/if}
+	{/if}
+</svelte:head>
 
 {@render children()}
 <Toast />


### PR DESCRIPTION
### Motivation
- Google Analytics was always injected into the base HTML which caused e2e runs and local dev servers to be counted as real users. 
- Analytics should only be active for release/production builds and must be disable-able for testing runs. 

### Description
- Remove the always-on GA snippet from `src/app.html` so it is no longer included unconditionally. 
- Inject the GA scripts from `src/routes/+layout.svelte` only when `!dev && !import.meta.env.VITE_DISABLE_GA` is true. 
- Prevent analytics during Playwright e2e runs by setting `VITE_DISABLE_GA=true` in the `webServer.command` in `playwright.config.ts`. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8d0ef860832eaf2b80b05165cd56)