### PR TITLE
Hide Playground page on mobile

### DIFF
--- a/src/lib/components/tui/TUINavigationTree.svelte
+++ b/src/lib/components/tui/TUINavigationTree.svelte
@@ -274,6 +274,7 @@
 		<a
 			href={flat.item.href}
 			class="nav-item"
+			class:playground={flat.item.href === '/playground'}
 			class:selected={index === selectedIndex}
 			class:current={isCurrentPath(flat.item.href)}
 			class:disabled={flat.item.disabled}
@@ -398,5 +399,11 @@
 	.label {
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	@media (max-width: 768px) {
+		.nav-item.playground {
+			display: none;
+		}
 	}
 </style>

--- a/src/routes/(app)/playground/+page.svelte
+++ b/src/routes/(app)/playground/+page.svelte
@@ -9,4 +9,27 @@
 	<title>Playground - {content.meta.title}</title>
 </svelte:head>
 
-<PlaygroundView />
+<section class="playground-page">
+	<p class="playground-mobile-message">Playground is available on desktop.</p>
+	<div class="playground-desktop">
+		<PlaygroundView />
+	</div>
+</section>
+
+<style>
+	.playground-mobile-message {
+		display: none;
+		margin: 0;
+		color: var(--text-secondary);
+	}
+
+	@media (max-width: 768px) {
+		.playground-desktop {
+			display: none;
+		}
+
+		.playground-mobile-message {
+			display: block;
+		}
+	}
+</style>


### PR DESCRIPTION
### Motivation
- The Playground UI is desktop-oriented and should not be exposed in the mobile drawer to avoid a poor experience on small screens.
- The navigation should not show the Playground entry on mobile to reduce clutter.
- When accessed on mobile, users should see a short message explaining the feature is desktop-only.

### Description
- Add a `playground` class binding to the nav anchor in `src/lib/components/tui/TUINavigationTree.svelte` and hide `.nav-item.playground` under `@media (max-width: 768px)`.
- Wrap `PlaygroundView` in `src/routes/(app)/playground/+page.svelte` with `.playground-desktop` and add a `.playground-mobile-message` that is shown only on small screens.
- Changes touch two files: `src/lib/components/tui/TUINavigationTree.svelte` and `src/routes/(app)/playground/+page.svelte`.

### Testing
- Started the dev server with `yarn dev` and Vite reported ready (dev server started successfully).
- Ran a Playwright script that loaded `/playground` at a mobile viewport and saved a screenshot to `artifacts/playground-mobile.png` (succeeded).
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e90568dd8832eb3d2970816d1dd39)