### PR TITLE
Fix playground layout heights

### DIFF
--- a/src/lib/components/playground/ToolSelector.svelte
+++ b/src/lib/components/playground/ToolSelector.svelte
@@ -132,7 +132,8 @@
 		gap: var(--spacing-sm);
 		padding: var(--spacing-xs);
 		overflow-y: auto;
-		max-height: 200px;
+		flex: 1;
+		min-height: 0;
 	}
 
 	.category {

--- a/src/routes/(app)/playground/+page.svelte
+++ b/src/routes/(app)/playground/+page.svelte
@@ -17,6 +17,18 @@
 </section>
 
 <style>
+	.playground-page {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		min-height: 0;
+	}
+
+	.playground-desktop {
+		flex: 1;
+		min-height: 0;
+	}
+
 	.playground-mobile-message {
 		display: none;
 		margin: 0;


### PR DESCRIPTION
### Motivation
- The playground desktop view and the tool selector no longer filled the available vertical space after styles were moved out of global scope.
- The change aims to keep the playground UI full-height without restoring global CSS rules.

### Description
- Updated `src/routes/(app)/playground/+page.svelte` to make `.playground-page` a flex column and set `.playground-desktop` to `flex: 1` with `min-height: 0` so the page fills available height.
- Updated `src/lib/components/playground/ToolSelector.svelte` to replace the fixed `max-height: 200px` with `flex: 1` and `min-height: 0` so the tool selector can grow to fill its panel.
- No global styles were reintroduced; changes are scoped to the playground components.

### Testing
- Started the dev server with `yarn dev` and Vite reported ready, indicating the app served successfully.
- Ran a Playwright script that navigated to `/playground` at `2048x1152`, captured a full-page screenshot, and completed successfully (screenshot saved to artifacts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e98428b94832e821473d766bf8570)