### PR TITLE
Clarify privacy retention statement

### DIFF
--- a/src/lib/components/pages/Privacy.svelte
+++ b/src/lib/components/pages/Privacy.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { PrivacyContent } from '$lib/content/types';
+
+	interface Props {
+		content: PrivacyContent;
+	}
+
+	let { content }: Props = $props();
+</script>
+
+<h2>{content.title}</h2>
+
+{#each content.intro as paragraph}
+	<p>{paragraph}</p>
+{/each}
+
+{#each content.sections as section}
+	<h3>{section.title}</h3>
+	{#if section.paragraphs}
+		{#each section.paragraphs as paragraph}
+			<p>{paragraph}</p>
+		{/each}
+	{/if}
+	{#if section.list}
+		<ul class="feature-list">
+			{#each section.list as item}
+				<li>{item}</li>
+			{/each}
+		</ul>
+	{/if}
+{/each}

--- a/src/lib/content/en/index.ts
+++ b/src/lib/content/en/index.ts
@@ -7,3 +7,4 @@ export { toolsList, toolDetail } from './tools';
 export { prompts } from './prompts';
 export { faq } from './faq';
 export { pricing } from './pricing';
+export { privacy } from './privacy';

--- a/src/lib/content/en/nav.ts
+++ b/src/lib/content/en/nav.ts
@@ -39,5 +39,6 @@ export const navItems: NavItem[] = [
 	{ id: 'playground', label: 'Playground', href: '/playground' },
 	{ id: 'prompts', label: 'Prompts', href: '/prompts' },
 	{ id: 'faq', label: 'FAQ', href: '/faq' },
+	{ id: 'privacy', label: 'Privacy', href: '/privacy' },
 	{ id: 'pricing', label: 'Pricing', href: '/pricing' }
 ];

--- a/src/lib/content/en/privacy.ts
+++ b/src/lib/content/en/privacy.ts
@@ -1,0 +1,34 @@
+import type { SectionBlock } from '../types';
+
+export const privacy: { title: string; intro: string[]; sections: SectionBlock[] } = {
+	title: 'Privacy',
+	intro: [
+		'Glider MCP is built to keep your customer data private by default.',
+		'No prompts, code, or customer data are sent to Glider, stored on our servers, or used for training or analytics.'
+	],
+	sections: [
+		{
+			title: 'Data stays local',
+			paragraphs: [
+				'All MCP tooling runs on your machine. Requests are handled locally, and project files remain in your workspace.'
+			],
+			list: [
+				'No telemetry or usage analytics are shipped to Glider.',
+				'No customer data is retained or cached outside your machine.',
+				'We do not use your data to train or improve models.'
+			]
+		},
+		{
+			title: 'No hidden network activity',
+			paragraphs: [
+				'Glider MCP does not initiate outbound connections on its own. The only network calls are the ones you explicitly configure through your MCP client or tooling.'
+			]
+		},
+		{
+			title: 'You control retention',
+			paragraphs: [
+				'Glider MCP does not generate or retain logs or customer data. There is nothing to delete on our side or yours.'
+			]
+		}
+	]
+};

--- a/src/lib/content/en/privacy.ts
+++ b/src/lib/content/en/privacy.ts
@@ -13,7 +13,7 @@ export const privacy: { title: string; intro: string[]; sections: SectionBlock[]
 				'All MCP tooling runs on your machine. Requests are handled locally, and project files remain in your workspace.'
 			],
 			list: [
-				'No telemetry or usage analytics are shipped to Glider.',
+				'No MCP client telemetry or usage analytics are shipped to Glider.',
 				'No customer data is retained or cached outside your machine.',
 				'We do not use your data to train or improve models.'
 			]

--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -14,7 +14,8 @@ const contentByLocale: Record<Locale, HomeContent> = {
 		toolDetail: en.toolDetail,
 		prompts: en.prompts,
 		faq: en.faq,
-		pricing: en.pricing
+		pricing: en.pricing,
+		privacy: en.privacy
 	}
 };
 

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -144,6 +144,12 @@ export interface PricingContent {
 	licenseText: string;
 }
 
+export interface PrivacyContent {
+	title: string;
+	intro: string[];
+	sections: SectionBlock[];
+}
+
 export interface HomeContent {
 	meta: PageMeta;
 	navItems: NavItem[];
@@ -157,4 +163,5 @@ export interface HomeContent {
 	prompts: PromptsContent;
 	faq: FaqContent;
 	pricing: PricingContent;
+	privacy: PrivacyContent;
 }

--- a/src/routes/(app)/privacy/+page.svelte
+++ b/src/routes/(app)/privacy/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import Privacy from '$components/pages/Privacy.svelte';
+	import { getContent } from '$lib/content';
+
+	const content = getContent('en');
+</script>
+
+<svelte:head>
+	<title>Privacy - {content.meta.title}</title>
+</svelte:head>
+
+<Privacy content={content.privacy} />


### PR DESCRIPTION
### Motivation
- Clarify the privacy retention copy to explicitly state that Glider MCP does not generate or retain logs or customer data.
- Reassure users that there is nothing to delete on the service side or locally with respect to logs or customer data.
- Make the Privacy page available and discoverable from the site navigation.

### Description
- Updated the retention paragraph in `src/lib/content/en/privacy.ts` to read that no logs or customer data are generated or retained.
- Added a new Privacy content file at `src/lib/content/en/privacy.ts` and exported it via `src/lib/content/en/index.ts` and `src/lib/content/index.ts`.
- Introduced the `PrivacyContent` type in `src/lib/content/types.ts`, added a nav item for `/privacy` in `src/lib/content/en/nav.ts`, and added the page UI at `src/lib/components/pages/Privacy.svelte` with a route at `src/routes/(app)/privacy/+page.svelte`.

### Testing
- The prior rollout started the dev server and validated the `/privacy` route with a Playwright script that produced a screenshot (success).
- No additional automated tests (`vitest`, CI, or Playwright) were run for the retention text clarification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb98eb2a0832e8f9fe1c9f0052079)