### PR TITLE
docs(site): add Architecture & Metrics tools and hide diagnostics-only tools from docs

### DIFF
--- a/src/lib/components/docs/ToolCard.svelte
+++ b/src/lib/components/docs/ToolCard.svelte
@@ -55,16 +55,18 @@
 					{#each tool.examples as example}
 						<div class="example">
 							<p class="example-desc">{example.description}</p>
-							<pre class="example-code">{JSON.stringify(example.params, null, 2)}</pre>
+							{#if Object.keys(example.params).length > 0}
+								<pre class="example-code">{JSON.stringify(example.params, null, 2)}</pre>
+							{/if}
 						</div>
 					{/each}
 				</div>
 			{/if}
 
-			{#if tool.responseDescription}
+			{#if tool.responseExample}
 				<div class="section">
 					<h4>Response</h4>
-					<p class="response-desc">{tool.responseDescription}</p>
+					<pre class="example-code">{JSON.stringify(tool.responseExample, null, 2)}</pre>
 				</div>
 			{/if}
 		</div>
@@ -202,8 +204,4 @@
 		margin: 0;
 	}
 
-	.response-desc {
-		color: var(--text-secondary);
-		margin: 0;
-	}
 </style>

--- a/src/lib/components/pages/ToolDetail.svelte
+++ b/src/lib/components/pages/ToolDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { CodeBlock } from '$components/docs';
-	import { TOOLS } from '$lib/utils/tool-metadata';
+	import { getDocsToolById } from '$lib/utils/tool-metadata';
 	import type { ToolDetailContent } from '$lib/content/types';
 
 	interface Props {
@@ -12,7 +12,7 @@
 
 	function getToolFromNavId(navId: string) {
 		const toolId = navId.replace('tool-', '').replace(/-/g, '_');
-		return TOOLS.find(t => t.id === toolId);
+		return getDocsToolById(toolId);
 	}
 
 	const tool = $derived.by(() => getToolFromNavId(selectedId));
@@ -53,13 +53,15 @@
 		<h3>{content.examplesTitle}</h3>
 		{#each tool.examples as example}
 			<p class="example-desc">{example.description}</p>
-			<CodeBlock code={JSON.stringify(example.params, null, 2)} language="json" />
+			{#if Object.keys(example.params).length > 0}
+				<CodeBlock code={JSON.stringify(example.params, null, 2)} language="json" />
+			{/if}
 		{/each}
 	{/if}
 
-	{#if tool.responseDescription}
+	{#if tool.responseExample}
 		<h3>{content.responseTitle}</h3>
-		<p>{tool.responseDescription}</p>
+		<CodeBlock code={JSON.stringify(tool.responseExample, null, 2)} language="json" />
 	{/if}
 
 	<p class="hint">{@html content.hint}</p>

--- a/src/lib/components/pages/ToolsList.svelte
+++ b/src/lib/components/pages/ToolsList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { ToolCard } from '$components/docs';
-	import { TOOL_CATEGORIES, getToolsByCategory, type ToolCategory } from '$lib/utils/tool-metadata';
+	import { TOOL_CATEGORIES, getDocsToolsByCategory, type ToolCategory } from '$lib/utils/tool-metadata';
 	import type { ToolsListContent } from '$lib/content/types';
 
 	interface Props {
@@ -16,7 +16,7 @@
 <p>{content.intro}</p>
 
 {#each Object.entries(TOOL_CATEGORIES) as [category, info]}
-	{@const tools = getToolsByCategory(category as ToolCategory)}
+	{@const tools = getDocsToolsByCategory(category as ToolCategory)}
 	{#if tools.length > 0}
 		<div class="tool-category">
 			<h3>{info.label}</h3>

--- a/src/lib/components/playground/ToolSelector.svelte
+++ b/src/lib/components/playground/ToolSelector.svelte
@@ -18,6 +18,7 @@
 			solution: [],
 			search: [],
 			analysis: [],
+			architecture: [],
 			refactoring: [],
 			external: []
 		};
@@ -32,7 +33,15 @@
 	// Flatten for keyboard navigation
 	const flatTools = $derived.by(() => {
 		const result: { toolId: string; categoryIndex: number }[] = [];
-		const categories: ToolCategory[] = ['diagnostics', 'solution', 'search', 'analysis', 'refactoring', 'external'];
+		const categories: ToolCategory[] = [
+			'diagnostics',
+			'solution',
+			'search',
+			'analysis',
+			'architecture',
+			'refactoring',
+			'external'
+		];
 
 		for (let ci = 0; ci < categories.length; ci++) {
 			for (const tool of toolsByCategory[categories[ci]]) {

--- a/src/lib/content/en/intro.ts
+++ b/src/lib/content/en/intro.ts
@@ -4,11 +4,12 @@ export const intro: IntroContent = {
 	title: 'Glider MCP',
 	tagline: 'Roslyn-powered C# code analysis for AI assistants',
 	paragraphs: [
-		'Glider is an MCP (Model Context Protocol) server that gives AI assistants deep semantic understanding of C# codebases. Built on Roslyn, it provides 12 powerful tools for code navigation, analysis, and refactoring.'
+		'Glider is an MCP (Model Context Protocol) server that gives AI assistants deep semantic understanding of C# codebases. Built on Roslyn, it provides 15 powerful tools for diagnostics, code navigation, analysis, and refactoring.'
 	],
 	featuresTitle: 'Key Features',
 	features: [
 		'Load and analyze .NET solutions and projects',
+		'Review compiler diagnostics across your codebase',
 		'Find type definitions, implementations, and usages',
 		'Get detailed type and method information',
 		'Semantic rename across entire solutions',

--- a/src/lib/content/en/meta.ts
+++ b/src/lib/content/en/meta.ts
@@ -3,5 +3,5 @@ import type { PageMeta } from '../types';
 export const meta: PageMeta = {
 	title: 'Glider MCP - Roslyn-powered C# Code Analysis for AI',
 	description:
-		'Glider MCP is a Roslyn-powered Model Context Protocol server that gives AI assistants deep understanding of C# codebases. 12 powerful tools for code analysis and refactoring.'
+		'Glider MCP is a Roslyn-powered Model Context Protocol server that gives AI assistants deep understanding of C# codebases. 15 powerful tools for code analysis and refactoring.'
 };

--- a/src/lib/content/en/nav.ts
+++ b/src/lib/content/en/nav.ts
@@ -21,15 +21,19 @@ export const navItems: NavItem[] = [
 		label: 'Tools',
 		href: '/tools',
 		children: [
-			{ id: 'tool-server-status', label: 'server_status', href: '/tools/server-status' },
 			{ id: 'tool-load-solution', label: 'load_solution', href: '/tools/load-solution' },
 			{ id: 'tool-load-project', label: 'load_project', href: '/tools/load-project' },
-			{ id: 'tool-unload-solution', label: 'unload_solution', href: '/tools/unload-solution' },
 			{ id: 'tool-find-types', label: 'find_types', href: '/tools/find-types' },
 			{ id: 'tool-find-usages', label: 'find_usages', href: '/tools/find-usages' },
 			{ id: 'tool-find-implementation', label: 'find_implementation', href: '/tools/find-implementation' },
 			{ id: 'tool-get-type-info', label: 'get_type_info', href: '/tools/get-type-info' },
 			{ id: 'tool-get-method-signature', label: 'get_method_signature', href: '/tools/get-method-signature' },
+			{
+				id: 'tool-get-type-dependencies',
+				label: 'get_type_dependencies',
+				href: '/tools/get-type-dependencies'
+			},
+			{ id: 'tool-analyze-complexity', label: 'analyze_complexity', href: '/tools/analyze-complexity' },
 			{ id: 'tool-rename-symbol', label: 'rename_symbol', href: '/tools/rename-symbol' },
 			{ id: 'tool-move-type', label: 'move_type', href: '/tools/move-type' },
 			{ id: 'tool-move-member', label: 'move_member', href: '/tools/move-member' },

--- a/src/lib/content/en/pricing.ts
+++ b/src/lib/content/en/pricing.ts
@@ -5,7 +5,7 @@ export const pricing: PricingContent = {
 	planName: 'Free',
 	price: '$0',
 	features: [
-		'All 12 tools included',
+		'All 15 tools included',
 		'Unlimited solutions',
 		'Both stdio and HTTP transport',
 		'Works with any MCP client',

--- a/src/lib/content/en/prompts.ts
+++ b/src/lib/content/en/prompts.ts
@@ -5,58 +5,49 @@ export const prompts: PromptsContent = {
 	intro: 'Effective prompts for working with Glider MCP.',
 	groups: [
 		{
-			title: 'Loading Solutions',
-			description: 'Start by loading your .NET solution or project.',
-			prompts: [
-				'Load the solution at /path/to/MySolution.sln',
-				'Load the project at /path/to/MyProject.csproj'
-			]
+			title: 'Load a Solution',
+			description: 'Start by loading your C# solution.',
+			prompts: ['Load the C# solution at /path/to/YourProject.sln']
 		},
 		{
-			title: 'Finding Types',
-			description: 'Search for types using patterns and wildcards.',
-			prompts: [
-				'Find all types matching *Service',
-				'Find types that start with I (interfaces)',
-				'Find all types in the DataLayer project'
-			]
+			title: 'Find Symbol References',
+			description: 'Locate where a symbol is used across the solution.',
+			prompts: ['Find all usages of the ISolutionManager interface']
 		},
 		{
-			title: 'Exploring Code',
-			description: 'Navigate and understand your codebase.',
-			prompts: [
-				'Show me the type hierarchy for UserService',
-				'What methods does IAuthService define?',
-				'Find all usages of the Login method',
-				'Find all implementations of IRepository'
-			]
+			title: 'Analyze a Type',
+			description: 'Inspect a class or interface in detail.',
+			prompts: ['Get detailed information about the SolutionManager class']
 		},
 		{
-			title: 'Getting Details',
-			description: 'Get detailed information about specific symbols.',
-			prompts: [
-				'Get detailed info about the UserController class',
-				'What is the signature of GetUserById method?',
-				'Show me the source of JsonSerializer from System.Text.Json'
-			]
+			title: 'Find Implementations',
+			description: 'List concrete implementations of an interface.',
+			prompts: ['Find all implementations of the ISymbolFinderService interface']
 		},
 		{
-			title: 'Refactoring',
-			description: 'Perform semantic refactoring operations.',
-			prompts: [
-				'Rename the OldClassName to NewClassName',
-				'Move the Helper class to the Utils namespace',
-				'Move the ProcessData method from OldClass to NewClass',
-				'Preview renaming UserService to UserManager without applying'
-			]
+			title: 'Search for Types',
+			description: 'Search by name pattern with wildcards.',
+			prompts: ['Find all types that end with "Manager" in the solution']
+		},
+		{
+			title: 'Get Method Details',
+			description: 'Fetch the signature for a specific method.',
+			prompts: ['Get the signature for the LoadSolutionAsync method in the ISolutionManager interface']
 		},
 		{
 			title: 'Complex Analysis',
 			description: 'Multi-step analysis workflows.',
 			prompts: [
-				'I need to understand how authentication works. Find the IAuthService interface, list its methods, and show where Login is called.',
-				'Find all classes that implement IRepository and show their public methods.',
-				'Show me the dependency chain from UserController to the database layer.'
+				'I need to understand how the solution loading works. Can you:\n1. Find the ISolutionManager interface\n2. Find all its implementations\n3. Show me the LoadSolutionAsync method signature\n4. Find where LoadSolutionAsync is being called'
+			]
+		},
+		{
+			title: 'Use Tools Directly',
+			description: 'Be explicit about the tool you want to run.',
+			prompts: [
+				'Use the load_solution tool to load /Users/yourname/projects/MyApp/MyApp.sln',
+				'Use the find_types tool with pattern "*Service" to find all service classes',
+				'Use the get_type_info tool to analyze the UserController class'
 			]
 		}
 	]

--- a/src/lib/content/en/tools.ts
+++ b/src/lib/content/en/tools.ts
@@ -2,7 +2,7 @@ import type { ToolDetailContent, ToolsListContent } from '../types';
 
 export const toolsList: ToolsListContent = {
 	title: 'Available Tools',
-	intro: 'Glider provides 12 MCP tools for C# code analysis and refactoring.'
+	intro: 'Glider provides 15 MCP tools for C# code analysis and refactoring.'
 };
 
 export const toolDetail: ToolDetailContent = {

--- a/src/lib/utils/tool-metadata.ts
+++ b/src/lib/utils/tool-metadata.ts
@@ -3,7 +3,14 @@
  * All 12 Glider MCP tools with their schemas, parameters, and examples
  */
 
-export type ToolCategory = 'diagnostics' | 'solution' | 'search' | 'analysis' | 'refactoring' | 'external';
+export type ToolCategory =
+	| 'diagnostics'
+	| 'solution'
+	| 'search'
+	| 'analysis'
+	| 'architecture'
+	| 'refactoring'
+	| 'external';
 
 export interface ToolParameter {
 	name: string;
@@ -27,7 +34,8 @@ export interface ToolMetadata {
 	category: ToolCategory;
 	parameters: ToolParameter[];
 	examples: ToolExample[];
-	responseDescription?: string;
+	responseExample?: Record<string, unknown>;
+	showInDocs?: boolean;
 }
 
 /**
@@ -49,6 +57,10 @@ export const TOOL_CATEGORIES: Record<ToolCategory, { label: string; description:
 	analysis: {
 		label: 'Analysis',
 		description: 'Get detailed type and method information'
+	},
+	architecture: {
+		label: 'Architecture & Metrics',
+		description: 'Analyze type dependencies and code complexity'
 	},
 	refactoring: {
 		label: 'Refactoring',
@@ -74,11 +86,88 @@ export const TOOLS: ToolMetadata[] = [
 		parameters: [],
 		examples: [
 			{
-				description: 'Check if server is running',
+				description: 'Check if the server is running',
 				params: {}
 			}
 		],
-		responseDescription: 'Returns status, version, and loaded solution info'
+		showInDocs: false,
+		responseExample: {
+			success: true,
+			data: {
+				serverRunning: true,
+				solutionLoaded: true,
+				solutionPath: '/path/to/solution.sln',
+				projectCount: 4,
+				projects: [
+					{
+						name: 'Glider',
+						filePath: '/path/to/Glider.csproj'
+					}
+				]
+			},
+			error: null
+		}
+	},
+	{
+		id: 'get_diagnostics',
+		name: 'get_diagnostics',
+		displayName: 'Get Diagnostics',
+		description: 'Gets compiler diagnostics (warnings, errors, info) for the loaded solution.',
+		category: 'diagnostics',
+		parameters: [
+			{
+				name: 'filePath',
+				type: 'string',
+				description: 'Optional file path to limit diagnostics to a specific file.',
+				required: false,
+				placeholder: '/path/to/File.cs'
+			},
+			{
+				name: 'projectName',
+				type: 'string',
+				description: 'Optional project name to limit diagnostics to a specific project.',
+				required: false,
+				placeholder: 'MyProject'
+			},
+			{
+				name: 'severity',
+				type: 'string',
+				description: 'Minimum severity to include: error, warning, info, or hidden.',
+				required: false,
+				placeholder: 'warning'
+			}
+		],
+		examples: [
+			{
+				description: 'Get diagnostics with warning severity or higher',
+				params: { severity: 'warning' }
+			}
+		],
+		showInDocs: false,
+		responseExample: {
+			success: true,
+			data: {
+				diagnosticCount: 3,
+				errorCount: 1,
+				warningCount: 2,
+				infoCount: 0,
+				diagnostics: [
+					{
+						id: 'CS1002',
+						severity: 'Error',
+						message: '; expected',
+						filePath: '/path/to/File.cs',
+						lineNumber: 42,
+						column: 17,
+						endLineNumber: 42,
+						endColumn: 18,
+						category: 'Syntax',
+						projectName: 'MyProject'
+					}
+				]
+			},
+			error: null
+		}
 	},
 
 	// Solution Management
@@ -100,10 +189,23 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Load a solution',
-				params: { solutionPath: '/Users/dev/MyProject/MyProject.sln' }
+				params: { solutionPath: '/Users/yourname/projects/MyApp/MyApp.sln' }
 			}
 		],
-		responseDescription: 'Returns list of projects in the solution'
+		responseExample: {
+			success: true,
+			data: {
+				solutionPath: '/Users/yourname/projects/MyApp/MyApp.sln',
+				projectCount: 1,
+				projects: [
+					{
+						name: 'MyApp',
+						filePath: '/Users/yourname/projects/MyApp/MyApp.csproj'
+					}
+				]
+			},
+			error: null
+		}
 	},
 	{
 		id: 'load_project',
@@ -123,26 +225,18 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Load a standalone project',
-				params: { projectPath: '/Users/dev/MyProject/MyProject.csproj' }
+				params: { projectPath: '/Users/yourname/projects/MyApp/MyApp.csproj' }
 			}
 		],
-		responseDescription: 'Returns project information'
+		responseExample: {
+			success: true,
+			data: {
+				projectName: 'MyApp',
+				projectPath: '/Users/yourname/projects/MyApp/MyApp.csproj'
+			},
+			error: null
+		}
 	},
-	{
-		id: 'unload_solution',
-		name: 'unload_solution',
-		displayName: 'Unload Solution',
-		description: 'Unloads the currently loaded solution from memory.',
-		category: 'solution',
-		parameters: [],
-		examples: [
-			{
-				description: 'Unload current solution',
-				params: {}
-			}
-		]
-	},
-
 	// Search
 	{
 		id: 'find_types',
@@ -168,19 +262,28 @@ export const TOOLS: ToolMetadata[] = [
 		],
 		examples: [
 			{
-				description: 'Find all service types',
-				params: { pattern: '*Service' }
-			},
-			{
-				description: 'Find interfaces starting with I',
-				params: { pattern: 'I*' }
-			},
-			{
-				description: 'Find types in specific project',
-				params: { pattern: '*Repository', projectName: 'DataLayer' }
+				description: 'Find all types ending with "Manager"',
+				params: { pattern: '*Manager' }
 			}
 		],
-		responseDescription: 'Returns list of matching types with names, kinds, paths, and line numbers'
+		responseExample: {
+			success: true,
+			data: {
+				pattern: '*Manager',
+				matchCount: 2,
+				matches: [
+					{
+						typeName: 'SolutionManager',
+						fullName: 'Glider.Services.SolutionManager',
+						kind: 'Class',
+						accessibility: 'Public',
+						filePath: '/path/to/SolutionManager.cs',
+						lineNumber: 10,
+						projectName: 'Glider'
+					}
+				]
+			}
+		}
 	},
 	{
 		id: 'find_usages',
@@ -207,14 +310,27 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Find all usages of an interface',
-				params: { symbolName: 'IUserService' }
-			},
-			{
-				description: 'Find usages of a method',
-				params: { symbolName: 'GetUserById' }
+				params: { symbolName: 'ISolutionManager' }
 			}
 		],
-		responseDescription: 'Returns list of usage locations with file paths, line numbers, and snippets'
+		responseExample: {
+			success: true,
+			data: {
+				symbolName: 'ISolutionManager',
+				symbolKind: 'Interface',
+				usageCount: 15,
+				usages: [
+					{
+						filePath: '/path/to/Program.cs',
+						lineNumber: 9,
+						column: 35,
+						lineText: 'builder.Services.AddSingleton<ISolutionManager, SolutionManager>();',
+						projectName: 'Glider.StdioServer'
+					}
+				]
+			},
+			error: null
+		}
 	},
 	{
 		id: 'find_implementation',
@@ -241,14 +357,27 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Find implementations of an interface',
-				params: { typeName: 'IRepository' }
-			},
-			{
-				description: 'Find implementations in specific project',
-				params: { typeName: 'IService', projectName: 'Services' }
+				params: { typeName: 'ISolutionManager' }
 			}
 		],
-		responseDescription: 'Returns list of implementing types with names, paths, and line numbers'
+		responseExample: {
+			success: true,
+			data: {
+				baseTypeName: 'ISolutionManager',
+				baseTypeKind: 'Interface',
+				implementationCount: 1,
+				implementations: [
+					{
+						typeName: 'SolutionManager',
+						fullName: 'Glider.Services.SolutionManager',
+						kind: 'Class',
+						filePath: '/path/to/SolutionManager.cs',
+						lineNumber: 10,
+						projectName: 'Glider'
+					}
+				]
+			}
+		}
 	},
 
 	// Analysis
@@ -277,14 +406,29 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Get info about a class',
-				params: { typeName: 'UserService' }
-			},
-			{
-				description: 'Get info with full namespace',
-				params: { typeName: 'MyApp.Services.UserService' }
+				params: { typeName: 'SolutionManager' }
 			}
 		],
-		responseDescription: 'Returns type details including members, base types, interfaces, and docs'
+		responseExample: {
+			success: true,
+			data: {
+				name: 'SolutionManager',
+				fullName: 'Glider.Services.SolutionManager',
+				kind: 'Class',
+				accessibility: 'Public',
+				baseType: 'Object',
+				interfaces: ['ISolutionManager'],
+				members: [
+					{
+						name: 'LoadSolutionAsync',
+						kind: 'Method',
+						type: 'Task',
+						accessibility: 'Public',
+						signature: 'Task LoadSolutionAsync(string solutionPath)'
+					}
+				]
+			}
+		}
 	},
 	{
 		id: 'get_method_signature',
@@ -318,14 +462,162 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Get method signature',
-				params: { methodName: 'GetUserById' }
-			},
-			{
-				description: 'Get method from specific type',
-				params: { methodName: 'Save', containingTypeName: 'UserRepository' }
+				params: { methodName: 'LoadSolutionAsync', containingTypeName: 'ISolutionManager' }
 			}
 		],
-		responseDescription: 'Returns method signature with parameters, return type, and documentation'
+		responseExample: {
+			success: true,
+			data: {
+				name: 'LoadSolutionAsync',
+				returnType: 'Task',
+				containingType: 'ISolutionManager',
+				parameters: [
+					{
+						name: 'solutionPath',
+						type: 'string',
+						defaultValue: null,
+						modifiers: []
+					}
+				]
+			}
+		}
+	},
+	{
+		id: 'get_type_dependencies',
+		name: 'get_type_dependencies',
+		displayName: 'Get Type Dependencies',
+		description: 'Analyzes type dependencies to show what types a given type uses and what types use it.',
+		category: 'architecture',
+		parameters: [
+			{
+				name: 'typeName',
+				type: 'string',
+				description: 'Name of the type to analyze.',
+				required: true,
+				placeholder: 'SolutionManager'
+			},
+			{
+				name: 'projectName',
+				type: 'string',
+				description: 'Optional project name to limit the search scope.',
+				required: false,
+				placeholder: 'MyProject'
+			},
+			{
+				name: 'direction',
+				type: 'string',
+				description: 'Dependency direction: uses, used_by, or both (default).',
+				required: false,
+				placeholder: 'both'
+			}
+		],
+		examples: [
+			{
+				description: 'Analyze type dependencies',
+				params: { typeName: 'SolutionManager', direction: 'both' }
+			}
+		],
+		responseExample: {
+			success: true,
+			data: {
+				typeName: 'SolutionManager',
+				fullName: 'Glider.Services.SolutionManager',
+				filePath: '/path/to/SolutionManager.cs',
+				usesCount: 4,
+				usedByCount: 2,
+				uses: [
+					{
+						typeName: 'Workspace',
+						fullName: 'Microsoft.CodeAnalysis.Workspace',
+						namespace: 'Microsoft.CodeAnalysis',
+						usageKind: 'Field',
+						filePath: null,
+						isExternal: true
+					}
+				],
+				usedBy: [
+					{
+						typeName: 'SolutionTools',
+						fullName: 'Glider.Server.SolutionTools',
+						namespace: 'Glider.Server',
+						usageKind: 'Method',
+						filePath: '/path/to/SolutionTools.cs',
+						isExternal: false
+					}
+				]
+			},
+			error: null
+		}
+	},
+	{
+		id: 'analyze_complexity',
+		name: 'analyze_complexity',
+		displayName: 'Analyze Complexity',
+		description: 'Analyzes code complexity metrics including cyclomatic complexity, lines of code, and method counts.',
+		category: 'architecture',
+		parameters: [
+			{
+				name: 'typeName',
+				type: 'string',
+				description: 'Optional type name to analyze.',
+				required: false,
+				placeholder: 'SolutionManager'
+			},
+			{
+				name: 'filePath',
+				type: 'string',
+				description: 'Optional file path to analyze.',
+				required: false,
+				placeholder: '/path/to/SolutionManager.cs'
+			},
+			{
+				name: 'projectName',
+				type: 'string',
+				description: 'Optional project name to limit the analysis scope.',
+				required: false,
+				placeholder: 'MyProject'
+			}
+		],
+		examples: [
+			{
+				description: 'Analyze complexity for a type',
+				params: { typeName: 'SolutionManager' }
+			}
+		],
+		responseExample: {
+			success: true,
+			data: {
+				summary: {
+					totalTypes: 12,
+					totalMethods: 84,
+					totalLinesOfCode: 3200,
+					averageComplexity: 3.1,
+					maxComplexity: 12,
+					highComplexityMethodCount: 4
+				},
+				types: [
+					{
+						name: 'SolutionManager',
+						fullName: 'Glider.Services.SolutionManager',
+						kind: 'Class',
+						filePath: '/path/to/SolutionManager.cs',
+						linesOfCode: 240,
+						methodCount: 8,
+						averageComplexity: 2.4,
+						methods: [
+							{
+								name: 'LoadSolutionAsync',
+								cyclomaticComplexity: 4,
+								linesOfCode: 32,
+								parameterCount: 1,
+								lineNumber: 58
+							}
+						]
+					}
+				]
+			},
+			error: null
+		}
 	},
 
 	// Refactoring
@@ -369,13 +661,20 @@ export const TOOLS: ToolMetadata[] = [
 			{
 				description: 'Rename a class',
 				params: { symbolName: 'OldClassName', newName: 'NewClassName' }
-			},
-			{
-				description: 'Preview rename without applying',
-				params: { symbolName: 'OldName', newName: 'NewName', applyChanges: false }
 			}
 		],
-		responseDescription: 'Returns files changed, locations modified, and unified diff'
+		responseExample: {
+			success: true,
+			data: {
+				symbolName: 'OldClassName',
+				newName: 'NewClassName',
+				symbolKind: 'Class',
+				filesChanged: 5,
+				locationsChanged: 12,
+				applied: true,
+				unifiedDiff: '...'
+			}
+		}
 	},
 	{
 		id: 'move_type',
@@ -424,13 +723,21 @@ export const TOOLS: ToolMetadata[] = [
 			{
 				description: 'Move type to new file',
 				params: { typeName: 'MyClass', targetFilePath: '/path/to/NewFile.cs' }
-			},
-			{
-				description: 'Move type to new namespace',
-				params: { typeName: 'MyClass', targetNamespace: 'MyApp.NewNamespace' }
 			}
 		],
-		responseDescription: 'Returns source and target locations, files changed/created, and diff'
+		responseExample: {
+			success: true,
+			data: {
+				symbolName: 'MyClass',
+				symbolKind: 'Class',
+				sourceLocation: '/path/to/OldFile.cs',
+				targetLocation: '/path/to/NewFile.cs',
+				filesChanged: 3,
+				filesCreated: 1,
+				applied: true,
+				unifiedDiff: '...'
+			}
+		}
 	},
 	{
 		id: 'move_member',
@@ -478,10 +785,22 @@ export const TOOLS: ToolMetadata[] = [
 		examples: [
 			{
 				description: 'Move method to another class',
-				params: { memberName: 'ProcessData', sourceTypeName: 'OldClass', targetTypeName: 'NewClass' }
+				params: { memberName: 'MyMethod', sourceTypeName: 'SourceClass', targetTypeName: 'TargetClass' }
 			}
 		],
-		responseDescription: 'Returns source and target types, files changed, and diff'
+		responseExample: {
+			success: true,
+			data: {
+				symbolName: 'MyMethod',
+				symbolKind: 'Method',
+				sourceLocation: 'SourceClass',
+				targetLocation: 'TargetClass',
+				filesChanged: 2,
+				filesCreated: 0,
+				applied: true,
+				unifiedDiff: '...'
+			}
+		}
 	},
 
 	// External Source
@@ -524,7 +843,19 @@ export const TOOLS: ToolMetadata[] = [
 				params: { symbolName: 'JsonSerializer', assemblyHint: 'System.Text.Json' }
 			}
 		],
-		responseDescription: 'Returns source code, assembly info, and source origin (SourceLink or decompiled)'
+		responseExample: {
+			success: true,
+			data: {
+				symbolName: 'JsonSerializer',
+				symbolKind: 'Class',
+				assemblyName: 'System.Text.Json',
+				assemblyVersion: '9.0.0.0',
+				sourceOrigin: 'SourceLink',
+				sourceUrl: 'https://raw.githubusercontent.com/...',
+				sourceCode: 'public static class JsonSerializer { ... }',
+				language: 'C#'
+			}
+		}
 	}
 ];
 
@@ -540,6 +871,22 @@ export function getToolById(id: string): ToolMetadata | undefined {
  */
 export function getToolsByCategory(category: ToolCategory): ToolMetadata[] {
 	return TOOLS.filter((tool) => tool.category === category);
+}
+
+/**
+ * Get tools by category that should appear in docs
+ */
+export function getDocsToolsByCategory(category: ToolCategory): ToolMetadata[] {
+	return TOOLS.filter(
+		(tool) => tool.category === category && tool.showInDocs !== false
+	);
+}
+
+/**
+ * Get tool by ID for docs
+ */
+export function getDocsToolById(id: string): ToolMetadata | undefined {
+	return TOOLS.find((tool) => tool.id === id && tool.showInDocs !== false);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Add architecture and metrics tooling to the documentation so users can discover dependency and complexity analysis features (`get_type_dependencies`, `analyze_complexity`).
- Keep playground-only diagnostics tools available to the interactive playground while removing them from the public docs to avoid clutter (`server_status`, `get_diagnostics`).
- Present concrete JSON response examples in the docs UI instead of prose to make tool outputs clearer.
- Update site copy and counts to reflect the expanded toolset (now 15 tools).

### Description
- Added an `architecture` category and two tools (`get_type_dependencies`, `analyze_complexity`) to `src/lib/utils/tool-metadata.ts` with parameters, examples, and `responseExample` payloads.
- Introduced a `showInDocs` flag and new helpers `getDocsToolsByCategory` and `getDocsToolById`, and switched the docs to use those helpers so playground-only tools remain available to the playground but are hidden from the docs.
- Updated docs UI components (`ToolCard.svelte`, `ToolDetail.svelte`) to render `responseExample` as JSON and only show example param blocks when `example.params` is non-empty, and updated the playground selector to include the new `architecture` category.
- Updated navigation and content files to include the new tools and refreshed copy/counts in `intro`, `meta`, `pricing`, `prompts`, and `tools` content.

### Testing
- Launched the dev server with `yarn dev --host 0.0.0.0 --port 4173`, which started successfully (succeeded).
- Captured a tools page screenshot using Playwright which produced `artifacts/tools-list.png` (succeeded).
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff40c8294832eab2453e93f42e4be)