### PR TITLE
Fix tool docs rendering, enable get_diagnostics docs, refresh code blocks, and wrap tool names

### DIFF
--- a/src/lib/components/docs/CodeBlock.svelte
+++ b/src/lib/components/docs/CodeBlock.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { getHighlighter, resolveLanguage } from '$lib/utils/shiki';
 
 	interface Props {
@@ -32,8 +31,8 @@
 		}
 	}
 
-	onMount(() => {
-		loadShiki();
+	$effect(() => {
+		void loadShiki();
 	});
 
 	async function copyToClipboard() {

--- a/src/lib/components/pages/ToolDetail.svelte
+++ b/src/lib/components/pages/ToolDetail.svelte
@@ -11,7 +11,8 @@
 	let { selectedId, content }: Props = $props();
 
 	function getToolFromNavId(navId: string) {
-		const toolId = navId.replace('tool-', '').replace(/-/g, '_');
+		const rawToolId = navId.replace('tool-', '').replace(/-/g, '_');
+		const toolId = rawToolId === 'view_external' ? 'view_external_definition' : rawToolId;
 		return getDocsToolById(toolId);
 	}
 

--- a/src/lib/components/playground/ToolSelector.svelte
+++ b/src/lib/components/playground/ToolSelector.svelte
@@ -176,9 +176,8 @@
 		background: none;
 		border: none;
 		cursor: pointer;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
+		white-space: normal;
+		word-break: break-word;
 	}
 
 	.tool-item:hover {

--- a/src/lib/content/en/nav.ts
+++ b/src/lib/content/en/nav.ts
@@ -21,6 +21,7 @@ export const navItems: NavItem[] = [
 		label: 'Tools',
 		href: '/tools',
 		children: [
+			{ id: 'tool-get-diagnostics', label: 'get_diagnostics', href: '/tools/get-diagnostics' },
 			{ id: 'tool-load-solution', label: 'load_solution', href: '/tools/load-solution' },
 			{ id: 'tool-load-project', label: 'load_project', href: '/tools/load-project' },
 			{ id: 'tool-find-types', label: 'find_types', href: '/tools/find-types' },
@@ -37,7 +38,11 @@ export const navItems: NavItem[] = [
 			{ id: 'tool-rename-symbol', label: 'rename_symbol', href: '/tools/rename-symbol' },
 			{ id: 'tool-move-type', label: 'move_type', href: '/tools/move-type' },
 			{ id: 'tool-move-member', label: 'move_member', href: '/tools/move-member' },
-			{ id: 'tool-view-external', label: 'view_external_definition', href: '/tools/view-external' }
+			{
+				id: 'tool-view-external-definition',
+				label: 'view_external_definition',
+				href: '/tools/view-external-definition'
+			}
 		]
 	},
 	{ id: 'playground', label: 'Playground', href: '/playground' },

--- a/src/lib/utils/tool-metadata.ts
+++ b/src/lib/utils/tool-metadata.ts
@@ -143,7 +143,6 @@ export const TOOLS: ToolMetadata[] = [
 				params: { severity: 'warning' }
 			}
 		],
-		showInDocs: false,
 		responseExample: {
 			success: true,
 			data: {


### PR DESCRIPTION
### Motivation
- The `view_external_definition` docs page rendered empty because route IDs didn't map to the correct tool metadata. 
- The `get_diagnostics` tool was hidden from docs and therefore its docs page was not available. 
- Code blocks showing example params did not refresh when the displayed tool changed, causing copied examples to differ from the visible text. 
- Long tool names in the TUI selector were truncated and needed to wrap so names are visible.

### Description
- Add a nav entry for `get_diagnostics` and update the `view-external` nav entry to `view-external-definition` in `src/lib/content/en/nav.ts` so routes match docs pages. 
- Map the legacy `view_external` nav id to `view_external_definition` in `src/lib/components/pages/ToolDetail.svelte` so the correct tool metadata is loaded. 
- Expose `get_diagnostics` in the docs by removing `showInDocs: false` from its metadata in `src/lib/utils/tool-metadata.ts`. 
- Refresh syntax highlighting when code blocks change by replacing `onMount` with a reactive `$effect` in `src/lib/components/docs/CodeBlock.svelte`, and allow tool selector entries to wrap by changing CSS (`white-space: normal; word-break: break-word;`) in `src/lib/components/playground/ToolSelector.svelte`.

### Testing
- Started the dev server with `npm run dev`, which came up and served the site successfully. 
- Ran a Playwright script that navigated to `/tools/get-diagnostics` and produced a screenshot artifact indicating the page loads correctly. 
- No automated unit test suite was executed as part of this change. 
- All automated steps performed (dev server and Playwright navigation) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696002cba568832ebe81ee4c4898927d)