### PR TITLE
feat: add .slnx support references to site content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ Edit `src/lib/content/en/installation.ts`:
 2. Add an `InstallationGuide` to `installationGuides`
 
 ### Adding a Tool
-Tools are defined in `src/lib/data/tools.ts` (the data), not content files. Tool UI labels are in `src/lib/content/en/tools.ts`.
+Tools are defined in `src/lib/utils/tool-metadata.ts` (the data), not content files. Tool UI labels are in `src/lib/content/en/tools.ts`.
 
 ### Adding Prompt Examples
 Edit `src/lib/content/en/prompts.ts`:

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ Make sure the .NET tools directory is on your `PATH`:
 
 ### Solution/project won’t load
 
-Use an absolute path to the `.sln` / `.csproj` file.
+Use an absolute path to the `.sln` / `.slnx` / `.csproj` file.

--- a/src/lib/content/en/prompts.ts
+++ b/src/lib/content/en/prompts.ts
@@ -9,6 +9,7 @@ export const prompts: PromptsContent = {
 			description: 'Start by loading your .NET solution or project. Enable file watching for automatic sync.',
 			prompts: [
 				'Load the solution at /path/to/MySolution.sln',
+				'Load the solution at /path/to/MySolution.slnx',
 				'Load /path/to/MySolution.sln and watch /path/to/workspace for changes',
 				'Load the project at /path/to/MyProject.csproj'
 			]

--- a/src/lib/content/en/quick-start.ts
+++ b/src/lib/content/en/quick-start.ts
@@ -36,6 +36,7 @@ dotnet tool list -g
 			paragraphs: ['Once configured, you can ask your AI assistant:'],
 			code: {
 				code: `"Load the solution at /path/to/MySolution.sln"
+"Load the solution at /path/to/MySolution.slnx"
 "Load the solution at /path/to/MySolution.sln with file watching in /path/to/workspace"
 "Use search_symbols with query *Service and kinds Type to find all service classes"
 "What methods does IUserRepository define?"

--- a/src/lib/utils/tool-metadata.ts
+++ b/src/lib/utils/tool-metadata.ts
@@ -155,13 +155,13 @@ export const TOOLS: ToolMetadata[] = [
 		id: 'load',
 		name: 'load',
 		displayName: 'Load',
-		description: 'Loads a C# solution (.sln) or project (.csproj) for analysis. Optionally enables automatic file watching when workingDirectory is provided.',
+		description: 'Loads a C# solution (.sln/.slnx) or project (.csproj) for analysis. Optionally enables automatic file watching when workingDirectory is provided.',
 		category: 'solution',
 		parameters: [
 			{
 				name: 'path',
 				type: 'string',
-				description: 'Absolute path to .sln or .csproj file to load.',
+				description: 'Absolute path to .sln, .slnx, or .csproj file to load.',
 				required: true,
 				placeholder: '/path/to/Solution.sln'
 			},


### PR DESCRIPTION
Update tool metadata, prompts, quick-start, README, and AGENTS.md to reference the new .slnx solution format alongside .sln/.csproj.