### PR TITLE
Rename pricing author section to Contact information and show email only

### DIFF
--- a/src/lib/components/pages/Pricing.svelte
+++ b/src/lib/components/pages/Pricing.svelte
@@ -38,8 +38,7 @@
 {/each}
 <CodeBlock code={content.updateCode.code} language={content.updateCode.language} />
 
-<h3>{content.authorTitle}</h3>
-<p>{content.authorLabel} <a href={content.authorUrl} class="link">{content.authorName}</a></p>
+<h3>{content.contactTitle}</h3>
 {#if email}
 	<p class="muted"><a href={mailto} class="link">{email}</a></p>
 {/if}

--- a/src/lib/content/en/pricing.ts
+++ b/src/lib/content/en/pricing.ts
@@ -20,10 +20,7 @@ export const pricing: PricingContent = {
 		code: 'dotnet tool update --global glider',
 		language: 'bash'
 	},
-	authorTitle: 'Author',
-	authorLabel: 'Built by',
-	authorName: 'Bogdan Novosad',
-	authorUrl: 'https://sacrorum.com',
+	contactTitle: 'Contact information',
 	licenseTitle: 'License',
 	licenseText: 'All Rights Reserved'
 };

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -148,10 +148,7 @@ export interface PricingContent {
 	versionPolicyTitle: string;
 	versionPolicy: string[];
 	updateCode: CodeSample;
-	authorTitle: string;
-	authorLabel: string;
-	authorName: string;
-	authorUrl: string;
+	contactTitle: string;
 	licenseTitle: string;
 	licenseText: string;
 }


### PR DESCRIPTION
### Motivation
- Replace the author block on the Pricing page with a simple contact entry so the page only exposes an email address instead of a "Built by" line and external author link.
- Simplify the `PricingContent` shape to remove multiple author fields and avoid stale author metadata in content.

### Description
- Replaced author fields in the content type by adding `contactTitle` in `src/lib/content/types.ts` and removed `authorTitle`, `authorLabel`, `authorName`, and `authorUrl`.
- Updated `src/lib/content/en/pricing.ts` to set `contactTitle: 'Contact information'` and removed the old author fields.
- Updated `src/lib/components/pages/Pricing.svelte` to render `content.contactTitle` and only display the obfuscated email link, removing the "Built by" line and external author link.
- Changed files: `src/lib/content/types.ts`, `src/lib/content/en/pricing.ts`, and `src/lib/components/pages/Pricing.svelte`.

### Testing
- Ran `yarn check` (Svelte diagnostics) which returned `0 errors and 0 warnings` and completed successfully.
- Captured an automated Playwright screenshot of `http://127.0.0.1:4173/pricing` to visually verify the change, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c0bf8418832eb27dd57335afed1d)