### PR TITLE
[codex] Mirror timeout contract docs

### DIFF
--- a/src/lib/components/playground/PlaygroundView.svelte
+++ b/src/lib/components/playground/PlaygroundView.svelte
@@ -46,24 +46,6 @@
 		return toolId.replace(/_/g, '-');
 	}
 
-	function resolveRequestTimeoutMs(params: Record<string, unknown>): number | null | undefined {
-		const timeout = params.timeout_ms;
-		if (typeof timeout !== 'number') {
-			return undefined;
-		}
-
-		if (timeout === 0) {
-			return null;
-		}
-
-		if (timeout > 0) {
-			// Keep client timeout slightly above tool timeout so server-side timeout decides first.
-			return Math.max(120000, timeout + 10000);
-		}
-
-		return undefined;
-	}
-
 	async function connect(): Promise<void> {
 		connectionAttempted = true;
 		setConnectionStatus('connecting');
@@ -113,10 +95,7 @@
 		setExecutionState('executing');
 
 		try {
-			const requestTimeoutMs = resolveRequestTimeoutMs(validation.normalizedParams);
-			const result = await mcpClient.callTool(executingTool.name, validation.normalizedParams, {
-				requestTimeoutMs
-			});
+			const result = await mcpClient.callTool(executingTool.name, validation.normalizedParams);
 
 			if (!result.success) {
 				setResponse({

--- a/src/lib/content/en/faq.ts
+++ b/src/lib/content/en/faq.ts
@@ -38,7 +38,8 @@ export const faq: FaqContent = {
 		{
 			question: 'Can I use HTTP transport?',
 			answer: [
-				'Yes. Run <code>glider --transport http</code> to start a Streamable HTTP MCP server (default: <code>http://localhost:5001/mcp</code>). This is useful for clients like Codex that connect over HTTP.'
+				'Yes. Run <code>glider --transport http</code> to start a Streamable HTTP MCP server (default: <code>http://localhost:5001/mcp</code>). This is useful for clients like Codex that connect over HTTP.',
+				'Async tools use a 20 minute server-side default timeout. Increase it with <code>glider --default-timeout 30m</code>, or use <code>0</code> to disable it entirely. Supported units: <code>ms</code>, <code>s</code>, and <code>m</code>.'
 			]
 		},
 		{

--- a/src/lib/content/en/installation.ts
+++ b/src/lib/content/en/installation.ts
@@ -32,7 +32,8 @@ export const installation: InstallationContent = {
 	intro: [
 		'Choose your AI client below for specific setup instructions. Glider works with any MCP-compatible client.',
 		'<strong>Recommendation:</strong> prefer <strong>project/workspace</strong> configuration when your client supports it. This avoids launching Glider for unrelated projects (and can help reduce token usage).',
-		'In stdio mode, <code>glider</code> waits for MCP input and is intentionally quiet by default. Use <code>glider --verbose</code> if you want a startup banner/logs (written to stderr).'
+		'In stdio mode, <code>glider</code> waits for MCP input and is intentionally quiet by default. Use <code>glider --verbose</code> if you want a startup banner/logs (written to stderr).',
+		'Async tools use a 20 minute server-side default timeout. Increase it with <code>glider --default-timeout 30m</code>, or use <code>0</code> to disable it. Supported units: <code>ms</code>, <code>s</code>, and <code>m</code>.'
 	],
 	hint: 'Use Tab/Arrow keys to navigate, Enter to select.',
 	ariaLabel: 'Installation guides',
@@ -79,6 +80,12 @@ export const installationGuides: InstallationGuides = {
 				code: 'claude mcp add --transport stdio glider --scope user -- glider'
 			},
 			{
+				title: 'Optional: increase the default async-tool timeout',
+				description:
+					'For larger solutions, pass <code>--default-timeout</code> through to Glider. Use duration values like <code>45s</code>, <code>30m</code>, or <code>0</code> to disable the server-side timeout.',
+				code: 'claude mcp add --transport stdio glider --scope project -- glider --default-timeout 30m'
+			},
+			{
 				title: 'Verify',
 				description: 'Start a new Claude Code session and check for Glider tools. If you need startup output/logs, re-add Glider with <code>--verbose</code> (e.g. <code>... -- glider --verbose</code>).',
 				code: 'claude\n# Then ask: "What Glider tools are available?"'
@@ -104,8 +111,8 @@ export const installationGuides: InstallationGuides = {
 			{
 				title: 'Start Glider (Streamable HTTP)',
 				description:
-					'Codex currently supports MCP servers over <strong>Streamable HTTP</strong>. Start Glider in HTTP mode (default endpoint: <code>http://localhost:5001/mcp</code>). Add <code>--verbose</code> for logs if needed.',
-				code: 'glider --transport http',
+					'Codex currently supports MCP servers over <strong>Streamable HTTP</strong>. Start Glider in HTTP mode (default endpoint: <code>http://localhost:5001/mcp</code>). Add <code>--verbose</code> for logs if needed. Use <code>--default-timeout</code> to raise the 20 minute server-side timeout for larger solutions.',
+				code: 'glider --transport http --default-timeout 30m',
 				language: 'bash'
 			},
 			{
@@ -115,7 +122,7 @@ export const installationGuides: InstallationGuides = {
 				code: `# ~/.codex/config.toml
 [mcp_servers.glider]
 url = "http://localhost:5001/mcp"
-tool_timeout_sec = 300`,
+tool_timeout_sec = 1200`,
 				language: 'plaintext'
 			},
 			{
@@ -134,7 +141,7 @@ tool_timeout_sec = 300`,
 
 [profiles.glider.mcp_servers.glider]
 url = "http://localhost:5001/mcp"
-tool_timeout_sec = 300
+tool_timeout_sec = 1200
 
 # Run with:
 # codex --profile glider`,
@@ -161,7 +168,7 @@ tool_timeout_sec = 300
 			{
 				title: 'Project scope (recommended)',
 				description:
-					'Create <code>.gemini/settings.json</code> in your project. Gemini CLI docs: <a href="https://geminicli.com/docs/tools/mcp-server" target="_blank" rel="noreferrer">geminicli.com/docs/tools/mcp-server</a>.',
+					'Create <code>.gemini/settings.json</code> in your project. Gemini CLI docs: <a href="https://geminicli.com/docs/tools/mcp-server" target="_blank" rel="noreferrer">geminicli.com/docs/tools/mcp-server</a>. For larger solutions, set <code>args</code> to <code>["--default-timeout", "30m"]</code>.',
 				code: `{
   "mcpServers": {
     "glider": {
@@ -175,7 +182,7 @@ tool_timeout_sec = 300
 			{
 				title: 'Global scope (user settings)',
 				description:
-					'Create/modify your user settings file: macOS/Linux <code>~/.gemini/settings.json</code>, Windows <code>%USERPROFILE%\\.gemini\\settings.json</code>.',
+					'Create/modify your user settings file: macOS/Linux <code>~/.gemini/settings.json</code>, Windows <code>%USERPROFILE%\\.gemini\\settings.json</code>. You can also pass <code>["--default-timeout", "30m"]</code> in <code>args</code> if you want a longer server-side timeout everywhere.',
 				code: `{
   "mcpServers": {
     "glider": {
@@ -207,7 +214,7 @@ tool_timeout_sec = 300
 			{
 				title: 'Project scope (recommended)',
 				description:
-					'Create <code>.cursor/mcp.json</code> in your repo (recommended to avoid starting Glider for unrelated projects). Cursor MCP docs: <a href="https://cursor.com/docs/context/mcp#using-mcpjson" target="_blank" rel="noreferrer">https://cursor.com/docs/context/mcp#using-mcpjson</a>.',
+					'Create <code>.cursor/mcp.json</code> in your repo (recommended to avoid starting Glider for unrelated projects). Cursor MCP docs: <a href="https://cursor.com/docs/context/mcp#using-mcpjson" target="_blank" rel="noreferrer">https://cursor.com/docs/context/mcp#using-mcpjson</a>. For larger solutions, set <code>args</code> to <code>["--default-timeout", "30m"]</code>.',
 				code: `{
   "mcpServers": {
     "glider": {
@@ -221,7 +228,7 @@ tool_timeout_sec = 300
 			{
 				title: 'Global scope (user settings)',
 				description:
-					'Create/modify: macOS/Linux <code>~/.cursor/mcp.json</code>, Windows <code>%USERPROFILE%\\.cursor\\mcp.json</code>.',
+					'Create/modify: macOS/Linux <code>~/.cursor/mcp.json</code>, Windows <code>%USERPROFILE%\\.cursor\\mcp.json</code>. Add <code>["--default-timeout", "30m"]</code> under <code>args</code> if you want Glider to use a longer server-side timeout.',
 				code: `{
   "mcpServers": {
     "glider": {
@@ -253,7 +260,7 @@ tool_timeout_sec = 300
 			{
 				title: 'Project scope (recommended)',
 				description:
-					'Create <code>.vscode/mcp.json</code> in your repo. GitHub Copilot MCP docs: <a href="https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp" target="_blank" rel="noreferrer">docs.github.com/.../extending-copilot-chat-with-mcp</a>.',
+					'Create <code>.vscode/mcp.json</code> in your repo. GitHub Copilot MCP docs: <a href="https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp" target="_blank" rel="noreferrer">docs.github.com/.../extending-copilot-chat-with-mcp</a>. For larger solutions, set <code>args</code> to <code>["--default-timeout", "30m"]</code>.',
 				code: `{
   "servers": {
     "glider": {
@@ -293,7 +300,7 @@ export const installationOther: OtherInstallContent = {
 		{
 			title: 'Stdio Transport (common: mcpServers JSON)',
 			description:
-				'Many clients (Cursor, Gemini CLI, etc.) use this format. Replace the file location with your client’s recommended <strong>project/workspace</strong> config file.',
+				'Many clients (Cursor, Gemini CLI, etc.) use this format. Replace the file location with your client’s recommended <strong>project/workspace</strong> config file. For larger solutions, set <code>args</code> to <code>["--default-timeout", "30m"]</code>.',
 			code: {
 				code: `{
   "mcpServers": {
@@ -309,7 +316,7 @@ export const installationOther: OtherInstallContent = {
 		{
 			title: 'VS Code / Copilot (mcp.json)',
 			description:
-				'VS Code uses a different config format (see VS Code docs: <a href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers" target="_blank" rel="noreferrer">code.visualstudio.com/docs/copilot/chat/mcp-servers</a>).',
+				'VS Code uses a different config format (see VS Code docs: <a href="https://code.visualstudio.com/docs/copilot/chat/mcp-servers" target="_blank" rel="noreferrer">code.visualstudio.com/docs/copilot/chat/mcp-servers</a>). For larger solutions, set <code>args</code> to <code>["--default-timeout", "30m"]</code>.',
 			code: {
 				code: `{
   "servers": {
@@ -326,10 +333,10 @@ export const installationOther: OtherInstallContent = {
 		{
 			title: 'HTTP Transport',
 			description:
-				'If your client requires HTTP, start Glider in HTTP mode and point the client at the URL:',
+				'If your client requires HTTP, start Glider in HTTP mode and point the client at the URL. Async tools use a 20 minute server-side default timeout; change it with <code>--default-timeout</code> using values like <code>45s</code>, <code>30m</code>, or <code>0</code>:',
 			code: {
 				code: `# Start Glider in HTTP mode
-glider --transport http
+glider --transport http --default-timeout 30m
 
 # Then configure your client to connect to:
 # http://localhost:5001/mcp`,
@@ -339,7 +346,7 @@ glider --transport http
 		{
 			title: 'Environment Variables',
 			code: {
-				code: '# Custom port for HTTP transport\nglider --transport http --port 8080',
+				code: '# Custom port and timeout for HTTP transport\nglider --transport http --port 8080 --default-timeout 30m',
 				language: 'bash'
 			}
 		}

--- a/src/lib/content/en/quick-start.ts
+++ b/src/lib/content/en/quick-start.ts
@@ -48,7 +48,8 @@ dotnet tool list -g
 		{
 			title: 'Notes',
 			paragraphs: [
-				'In stdio mode, <code>glider</code> waits for MCP input and is intentionally quiet by default. Use <code>glider --verbose</code> if you want startup output/logs (written to stderr).'
+				'In stdio mode, <code>glider</code> waits for MCP input and is intentionally quiet by default. Use <code>glider --verbose</code> if you want startup output/logs (written to stderr).',
+				'Async tools use a 20 minute server-side default timeout. Increase it with <code>glider --default-timeout 30m</code>, or use <code>0</code> to disable it. Supported units: <code>ms</code>, <code>s</code>, and <code>m</code>.'
 			]
 		},
 		{

--- a/src/lib/generated/version.ts
+++ b/src/lib/generated/version.ts
@@ -1,5 +1,5 @@
 // Auto-generated. Do not edit.
 export const gliderVersion = {
-	version: '5.3.0',
-	fetchedAt: '2026-02-23T11:37:10.480Z'
+	version: '6.1.0',
+	fetchedAt: '2026-03-31T13:01:57.027Z'
 };

--- a/src/lib/services/mcp-client.ts
+++ b/src/lib/services/mcp-client.ts
@@ -31,7 +31,8 @@ export interface CallToolOptions {
 }
 
 const DEFAULT_BASE_URL = 'http://localhost:5001';
-const DEFAULT_TIMEOUT = 120000; // 120 seconds - solution loading can take a while
+// Keep the browser client above Glider's default 20 minute server timeout so the server decides first.
+const DEFAULT_TIMEOUT = 21 * 60 * 1000;
 const HEALTH_CHECK_INTERVAL = 5000; // 5 seconds
 
 class MCPClient {

--- a/src/lib/utils/__tests__/tool-metadata.test.ts
+++ b/src/lib/utils/__tests__/tool-metadata.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { getToolById, validateToolParams } from '../tool-metadata';
+import { TOOLS, getToolById, validateToolParams } from '../tool-metadata';
 
 describe('tool-metadata', () => {
 	it('exposes the batch tool', () => {
 		const tool = getToolById('batch');
 		expect(tool).toBeDefined();
 		expect(tool?.parameters.some((p) => p.name === 'operations' && p.type === 'json')).toBe(true);
+	});
+
+	it('does not expose timeout_ms as a public tool parameter', () => {
+		expect(TOOLS.some((tool) => tool.parameters.some((param) => param.name === 'timeout_ms'))).toBe(false);
 	});
 
 	it('validates required parameters', () => {
@@ -40,4 +44,3 @@ describe('tool-metadata', () => {
 		expect(bad.errors.join('\n')).toMatch(/operations must be valid JSON/);
 	});
 });
-

--- a/src/lib/utils/tool-metadata.ts
+++ b/src/lib/utils/tool-metadata.ts
@@ -178,13 +178,6 @@ export const TOOLS: ToolMetadata[] = [
 				description: 'Include detailed project information in response. Default is false.',
 				required: false,
 				default: false
-			},
-			{
-				name: 'timeout_ms',
-				type: 'number',
-				description: 'Timeout in milliseconds (10 minutes). Use 0 to disable. Default is 600000.',
-				required: false,
-				default: 600000
 			}
 		],
 		examples: [
@@ -209,7 +202,7 @@ export const TOOLS: ToolMetadata[] = [
 					loadedPath: '/Users/dev/MyProject/MyProject.sln'
 				}
 			},
-			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 600000 },
+			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 1200000 },
 			error: null
 		}
 	},
@@ -226,13 +219,6 @@ export const TOOLS: ToolMetadata[] = [
 				description: 'Include detailed project information in response. Default is false.',
 				required: false,
 				default: false
-			},
-			{
-				name: 'timeout_ms',
-				type: 'number',
-				description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.',
-				required: false,
-				default: 300000
 			}
 		],
 		examples: [{ description: 'Reload after manual edits', params: { includeProjects: true } }],
@@ -251,7 +237,7 @@ export const TOOLS: ToolMetadata[] = [
 					loadedPath: '/Users/dev/MyProject/MyProject.sln'
 				}
 			},
-			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 300000 },
+			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 1200000 },
 			error: null
 		}
 	},
@@ -284,13 +270,6 @@ export const TOOLS: ToolMetadata[] = [
 				description: "Path style: 'absolute' (default) or 'relative' (to solution root).",
 				required: false,
 				default: 'absolute'
-			},
-			{
-				name: 'timeout_ms',
-				type: 'number',
-				description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.',
-				required: false,
-				default: 300000
 			}
 		],
 		examples: [
@@ -333,8 +312,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'sortBy', type: 'string', description: "Optional sort: 'severity', 'filePath', 'id', 'lineNumber', 'projectName'.", required: false, placeholder: 'severity' },
 			{ name: 'sortOrder', type: 'string', description: "Sort order: 'asc' (default) or 'desc'.", required: false, default: 'asc' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 }
 		],
 		examples: [
 			{ description: 'Get warnings and errors (default)', params: {} },
@@ -365,7 +343,7 @@ export const TOOLS: ToolMetadata[] = [
 					}
 				]
 			},
-			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 300000 },
+			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 1200000 },
 			error: null
 		}
 	},
@@ -383,8 +361,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'kinds', type: 'string', description: "Optional kinds filter (comma-separated): 'Type,Method,Property,Field,Event'.", required: false, placeholder: 'Type,Method' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name to limit scope.', required: false, placeholder: 'MyProject' },
 			{ name: 'maxCandidates', type: 'number', description: 'Max candidates to return. Default is 25.', required: false, default: 25 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [
 			{ description: 'Resolve an ambiguous type name', params: { query: 'SolutionManager', kinds: 'Type' } },
@@ -408,7 +385,7 @@ export const TOOLS: ToolMetadata[] = [
 				],
 				hints: { nextSteps: ['Use get_symbol_info with a candidate symbolKey for details', 'Use find_references with symbolKey to locate usages'] }
 			},
-			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 300000 },
+			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 1200000 },
 			error: null
 		}
 	},
@@ -448,8 +425,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'sortBy', type: 'string', description: "Optional sort: 'name', 'kind', 'filePath', 'projectName', 'namespace'.", required: false, placeholder: 'name' },
 			{ name: 'sortOrder', type: 'string', description: "Sort order: 'asc' (default) or 'desc'.", required: false, default: 'asc' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 }
 		],
 		examples: [
 			{ description: 'Search for service types', params: { query: '*Service', kinds: 'Type' } },
@@ -492,8 +468,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'filePath', type: 'string', description: 'Absolute file path.', required: true, placeholder: '/path/to/File.cs' },
 			{ name: 'line', type: 'number', description: '1-based line number.', required: true, default: 1 },
 			{ name: 'column', type: 'number', description: '1-based column number.', required: true, default: 1 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get symbol key under cursor', params: { filePath: '/Users/dev/MyProject/Program.cs', line: 10, column: 15 } }],
 		responseDescription: 'Returns a symbol key and basic symbol details',
@@ -533,8 +508,7 @@ export const TOOLS: ToolMetadata[] = [
 				required: false,
 				default: 2000
 			},
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get symbol info from a symbol key', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns rich symbol information including signature and locations',
@@ -590,8 +564,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'groupBy', type: 'string', description: "Grouping: 'file', 'project', 'containingSymbol', or 'none' (default).", required: false, default: 'none' },
 			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 }
 		],
 		examples: [{ description: 'Find references for a symbolKey', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns reference locations (with paging)',
@@ -632,8 +605,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope for overrides search.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 }
 		],
 		examples: [{ description: 'Find overrides for a member', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns overriding members (with paging)',
@@ -675,8 +647,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope for implementation search.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 }
 		],
 		examples: [{ description: 'Find implementations for an interface', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns implementing symbols (with paging)',
@@ -722,8 +693,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional search scope.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
 			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [
 			{ description: 'Find async methods missing CancellationToken', params: { kinds: 'Method', modifiers: 'async', mustNotHaveParameterType: 'CancellationToken' } }
@@ -764,8 +734,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
 			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
 			{ name: 'maxLineTextChars', type: 'number', description: 'Max characters for lineText. Use 0 for unlimited. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Find TODO comments', params: { query: 'TODO' } }],
 		responseDescription: 'Returns matching text occurrences (with paging)',
@@ -801,7 +770,7 @@ export const TOOLS: ToolMetadata[] = [
 					unreadableNote: null
 				}
 			},
-			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 300000 },
+			meta: { durationMs: 123, cancelled: false, timedOut: false, timeoutMs: 1200000 },
 			error: null
 		}
 	},
@@ -827,8 +796,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope applied to derived type search.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'derivedSkip', type: 'number', description: 'Derived type paging offset. Default is 0.', required: false, default: 0 },
 			{ name: 'derivedTake', type: 'number', description: 'Derived type paging size. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get type hierarchy for a type symbolKey', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns base types, interfaces, and derived types (derived types support paging)',
@@ -861,8 +829,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope for derived type search.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
 			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get derived types', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns derived types (with paging)',
@@ -891,8 +858,7 @@ export const TOOLS: ToolMetadata[] = [
 				required: true,
 				placeholder: '...'
 			},
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Find original declaration for an override', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns the override chain and original declaration',
@@ -928,8 +894,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope for call site search.', required: false, placeholder: '{ "kind": "solution" }' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
 			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Find callers for a method', params: { symbolKey: '...' } }],
 		responseDescription: 'Returns call sites grouped by caller (with paging)',
@@ -967,8 +932,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'scope', type: 'json', description: 'Optional scope for outgoing call analysis.', required: false, placeholder: '{ "mode": "solution" }' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset. Default is 0.', required: false, default: 0 },
 			{ name: 'take', type: 'number', description: 'Pagination size. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get outgoing calls for a method', params: { symbolKey: '...', depth: 1 } }],
 		responseDescription: 'Returns outgoing calls (with paging)',
@@ -1007,8 +971,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'callersTake', type: 'number', description: 'Pagination size for callers summary. Default is 50.', required: false, default: 50 },
 			{ name: 'implementationsSkip', type: 'number', description: 'Pagination offset for implementations summary. Default is 0.', required: false, default: 0 },
 			{ name: 'implementationsTake', type: 'number', description: 'Pagination size for implementations summary. Default is 50.', required: false, default: 50 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Summarize impact of changing a method/type', params: { symbolKey: '...', includeCallers: true } }],
 		responseDescription: 'Returns an impact summary (and optionally detailed lists)',
@@ -1031,8 +994,7 @@ export const TOOLS: ToolMetadata[] = [
 		category: 'analysis',
 		parameters: [
 			{ name: 'typeName', type: 'string', description: 'Type name (simple or fully qualified).', required: true, placeholder: 'UserService' },
-			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' }
 		],
 		examples: [{ description: 'Get type info', params: { typeName: 'UserService' } }],
 		responseDescription: 'Returns type details including members',
@@ -1070,8 +1032,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'typeName', type: 'string', description: 'Type name (simple or fully qualified).', required: true, placeholder: 'UserService' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' },
 			{ name: 'maxLines', type: 'number', description: 'Max lines to return. Use 0 for unlimited. Default is 200.', required: false, default: 200 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get type source', params: { typeName: 'UserService' } }],
 		responseDescription: 'Returns type source (possibly truncated)',
@@ -1107,8 +1068,7 @@ export const TOOLS: ToolMetadata[] = [
 				placeholder: 'GetUserById'
 			},
 			{ name: 'containingTypeName', type: 'string', description: 'Optional containing type name filter.', required: false, placeholder: 'UserService' },
-			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' }
 		],
 		examples: [
 			{ description: 'Get method signature', params: { methodName: 'GetUserById' } },
@@ -1140,8 +1100,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' },
 			{ name: 'maxLines', type: 'number', description: 'Max lines to return. Use 0 for unlimited. Default is 120.', required: false, default: 120 },
 			{ name: 'bodyOnly', type: 'boolean', description: 'If true, return only the method body (no signature). Default is false.', required: false, default: false },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Get method source', params: { methodName: 'LoadSolutionAsync', containingTypeName: 'SolutionManager' } }],
 		responseDescription: 'Returns method source (possibly truncated)',
@@ -1169,8 +1128,7 @@ export const TOOLS: ToolMetadata[] = [
 		parameters: [
 			{ name: 'typeName', type: 'string', description: 'Type name to analyze.', required: true, placeholder: 'SolutionManager' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name filter.', required: false, placeholder: 'MyProject' },
-			{ name: 'direction', type: 'string', description: "Direction: 'uses', 'used_by', or 'both' (default).", required: false, default: 'both' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'direction', type: 'string', description: "Direction: 'uses', 'used_by', or 'both' (default).", required: false, default: 'both' }
 		],
 		examples: [{ description: 'Analyze dependencies', params: { typeName: 'SolutionManager' } }],
 		responseDescription: 'Returns types used by the target and types that reference it',
@@ -1220,8 +1178,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'sortBy', type: 'string', description: "Optional sort: 'complexity', 'averageComplexity', 'linesOfCode', 'methodCount', 'name'.", required: false, placeholder: 'complexity' },
 			{ name: 'sortOrder', type: 'string', description: "Sort order: 'asc' (default) or 'desc'.", required: false, default: 'asc' },
 			{ name: 'skip', type: 'number', description: 'Pagination offset over returned types. Default is 0.', required: false, default: 0 },
-			{ name: 'take', type: 'number', description: 'Pagination size over returned types. Default is 50.', required: false, default: 50 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'take', type: 'number', description: 'Pagination size over returned types. Default is 50.', required: false, default: 50 }
 		],
 		examples: [
 			{ description: 'Analyze overall complexity', params: {} },
@@ -1276,8 +1233,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'symbolName', type: 'string', description: 'Symbol name to rename (simple or fully qualified).', required: true, placeholder: 'OldClassName' },
 			{ name: 'newName', type: 'string', description: 'New name for the symbol.', required: true, placeholder: 'NewClassName' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name to limit symbol search.', required: false, placeholder: 'MyProject' },
-			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns a preview diff.', required: false, default: true },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns a preview diff.', required: false, default: true }
 		],
 		examples: [
 			{ description: 'Rename a class', params: { symbolName: 'OldClassName', newName: 'NewClassName' } },
@@ -1309,8 +1265,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'targetFilePath', type: 'string', description: 'Optional target file path.', required: false, placeholder: '/path/to/NewFile.cs' },
 			{ name: 'targetNamespace', type: 'string', description: 'Optional target namespace.', required: false, placeholder: 'MyApp.Utils' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name to limit symbol search.', required: false, placeholder: 'MyProject' },
-			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns a preview diff.', required: false, default: true },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns a preview diff.', required: false, default: true }
 		],
 		examples: [{ description: 'Move a type to a new namespace', params: { typeName: 'MyClass', targetNamespace: 'MyApp.Utils' } }],
 		responseDescription: 'Returns a unified diff of the change set',
@@ -1341,8 +1296,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'targetTypeName', type: 'string', description: 'Target type name.', required: true, placeholder: 'TargetClass' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name to limit search.', required: false, placeholder: 'MyProject' },
 			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns a preview diff.', required: false, default: true },
-			{ name: 'maxReferenceUpdates', type: 'number', description: 'Maximum reference updates when rewriting call sites. Use 0 to disable. Default is 2000.', required: false, default: 2000 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'maxReferenceUpdates', type: 'number', description: 'Maximum reference updates when rewriting call sites. Use 0 to disable. Default is 2000.', required: false, default: 2000 }
 		],
 		examples: [{ description: 'Move a method to another class', params: { memberName: 'ProcessData', sourceTypeName: 'OldClass', targetTypeName: 'NewClass' } }],
 		responseDescription: 'Returns a unified diff of the change set',
@@ -1373,8 +1327,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns preview only.', required: false, default: true },
 			{ name: 'includeDiff', type: 'boolean', description: 'Include unified diff in response. Default is true.', required: false, default: true },
 			{ name: 'maxDiffChars', type: 'number', description: 'Max diff characters. Use 0 for unlimited. Default is 50000.', required: false, default: 50000 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Preview organize usings', params: { filePath: '/Users/dev/MyProject/Program.cs', applyChanges: false } }],
 		responseDescription: 'Returns diff output for the formatting operation',
@@ -1403,8 +1356,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'applyChanges', type: 'boolean', description: 'If true (default), applies changes to disk. If false, returns preview only.', required: false, default: true },
 			{ name: 'includeDiff', type: 'boolean', description: 'Include unified diff in response. Default is true.', required: false, default: true },
 			{ name: 'maxDiffChars', type: 'number', description: 'Max diff characters. Use 0 for unlimited. Default is 50000.', required: false, default: 50000 },
-			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'pathStyle', type: 'string', description: "Path style: 'absolute' (default) or 'relative' (to solution root).", required: false, default: 'absolute' }
 		],
 		examples: [{ description: 'Preview formatting a file', params: { filePath: '/Users/dev/MyProject/Program.cs', applyChanges: false } }],
 		responseDescription: 'Returns diff output for the formatting operation',
@@ -1433,8 +1385,7 @@ export const TOOLS: ToolMetadata[] = [
 			{ name: 'symbolName', type: 'string', description: 'Symbol name to look up (simple or fully qualified).', required: true, placeholder: 'JsonSerializer' },
 			{ name: 'assemblyHint', type: 'string', description: 'Optional assembly name hint to narrow matches.', required: false, placeholder: 'System.Text.Json' },
 			{ name: 'projectName', type: 'string', description: 'Optional project name to limit referenced assemblies.', required: false, placeholder: 'MyProject' },
-			{ name: 'maxLines', type: 'number', description: 'Maximum number of source lines to return. Use 0 for no limit. Default is 400.', required: false, default: 400 },
-			{ name: 'timeout_ms', type: 'number', description: 'Timeout in milliseconds (5 minutes). Use 0 to disable. Default is 300000.', required: false, default: 300000 }
+			{ name: 'maxLines', type: 'number', description: 'Maximum number of source lines to return. Use 0 for no limit. Default is 400.', required: false, default: 400 }
 		],
 		examples: [
 			{ description: 'View JsonSerializer source', params: { symbolName: 'System.Text.Json.JsonSerializer', assemblyHint: 'System.Text.Json' } }
@@ -1481,13 +1432,6 @@ export const TOOLS: ToolMetadata[] = [
 				description: 'When true, stops after the first failure. Default is false.',
 				required: false,
 				default: false
-			},
-			{
-				name: 'timeout_ms',
-				type: 'number',
-				description: 'Overall batch timeout in milliseconds (10 minutes). Use 0 to disable. Default is 600000.',
-				required: false,
-				default: 600000
 			}
 		],
 		examples: [

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -52,9 +52,6 @@
     <loc>https://glidermcp.com/tools/analyze-complexity</loc>
   </url>
   <url>
-    <loc>https://glidermcp.com/tools/apply-code-fix</loc>
-  </url>
-  <url>
     <loc>https://glidermcp.com/tools/batch</loc>
   </url>
   <url>
@@ -74,9 +71,6 @@
   </url>
   <url>
     <loc>https://glidermcp.com/tools/format-document</loc>
-  </url>
-  <url>
-    <loc>https://glidermcp.com/tools/get-code-fixes</loc>
   </url>
   <url>
     <loc>https://glidermcp.com/tools/get-derived-types</loc>


### PR DESCRIPTION
## Summary
- remove public `timeout_ms` tool parameters from the site metadata and docs
- document Glider's new `--default-timeout` flag across installation, quick start, and FAQ content
- keep the playground aligned by using a client timeout above Glider's new 20 minute server default

## Why
Glider moved timeout control from per-tool request parameters to a server-wide CLI flag. The website and playground still reflected the old contract, which made the docs inaccurate and would have left the playground timing out too early once `timeout_ms` disappeared.

## Impact
- tool detail pages and playground forms no longer expose `timeout_ms`
- install docs now explain `--default-timeout` and update Codex examples to `tool_timeout_sec = 1200`
- the browser playground no longer depends on a removed timeout field and will let the server-side timeout win first

## Validation
- `yarn test`
- `yarn check`
- `yarn build`