### PR TITLE
feat(repo): add plugin marketplace assets

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "glidermcp",
+  "description": "GliderMCP plugins for coding agents.",
+  "plugins": [
+    {
+      "name": "glidermcp",
+      "description": "C# semantic navigation, diagnostics, references, call graphs, impact analysis, and safe refactoring for Codex.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/glidermcp"
+      }
+    }
+  ]
+}

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,6 +1,9 @@
 {
   "name": "glidermcp",
   "description": "GliderMCP plugins for coding agents.",
+  "interface": {
+    "displayName": "GliderMCP"
+  },
   "plugins": [
     {
       "name": "glidermcp",
@@ -8,7 +11,12 @@
       "source": {
         "source": "local",
         "path": "./plugins/glidermcp"
-      }
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "glidermcp",
+  "owner": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "plugins": [
+    {
+      "name": "glidermcp",
+      "source": "./plugins/glidermcp",
+      "description": "C# semantic navigation, diagnostics, references, call graphs, impact analysis, and safe refactoring for Claude Code."
+    }
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GliderMCP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ Please open issues in this repository and select the relevant product in the iss
 - Product site: https://glidermcp.com
 - NuGet package: https://www.nuget.org/packages/glider
 
+## Plugin and config assets
+
+This repository ships root-level marketplace and config assets for agent clients:
+
+- `plugins/glidermcp/` - shared plugin bundle with `.mcp.json` plus a C# workflow skill.
+- `.claude-plugin/marketplace.json` - Claude Code marketplace entry.
+- `.agents/plugins/marketplace.json` - Codex marketplace entry.
+- `install/claude-code/.mcp.json` - direct Claude Code project config template.
+- `install/codex/config.toml` - direct Codex global config snippet for HTTP transport.
+
+Claude Code plugin install:
+
+```bash
+claude plugin marketplace add glidermcp/glidermcp.com
+claude plugin install glidermcp@glidermcp
+```
+
+Codex plugin install:
+
+```bash
+codex plugin marketplace add glidermcp/glidermcp.com
+codex
+# Open /plugins and install glidermcp.
+```
+
 ## Notes
 
 - Pull requests with runtime/product code are not accepted in this repository.

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,31 @@
+# GliderMCP Install Assets
+
+This directory contains copyable config templates for users who prefer direct MCP setup over plugin marketplace setup.
+
+Prerequisites:
+
+- .NET 10 SDK
+- `dotnet tool install --global glider`
+- `glider` available on `PATH`
+
+Templates:
+
+- `claude-code/.mcp.json` - project-scoped Claude Code MCP config.
+- `codex/config.toml` - Codex global config snippet for Streamable HTTP.
+
+Plugin marketplace setup is also available from this repository:
+
+```bash
+# Claude Code
+claude plugin marketplace add glidermcp/glidermcp.com
+claude plugin install glidermcp@glidermcp
+
+# Codex
+codex plugin marketplace add glidermcp/glidermcp.com
+```
+
+For Codex direct config, start Glider separately with:
+
+```bash
+glider --transport http --default-timeout 30m
+```

--- a/install/claude-code/.mcp.json
+++ b/install/claude-code/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "glider": {
+      "command": "glider",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/install/codex/config.toml
+++ b/install/codex/config.toml
@@ -1,0 +1,8 @@
+[mcp_servers.glider]
+url = "http://localhost:5001/mcp"
+http_headers = { Accept = "application/json, text/event-stream" }
+startup_timeout_sec = 30
+tool_timeout_sec = 1200
+
+# Start separately:
+# glider --transport http --default-timeout 30m

--- a/plugins/glidermcp/.claude-plugin/plugin.json
+++ b/plugins/glidermcp/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "glidermcp",
+  "description": "Connect coding agents to the local GliderMCP C# semantic analysis server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "csharp",
+    "dotnet",
+    "mcp",
+    "semantic-code-navigation",
+    "roslyn"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/glidermcp/.codex-mcp.json
+++ b/plugins/glidermcp/.codex-mcp.json
@@ -1,5 +1,5 @@
 {
-  "mcpServers": {
+  "mcp_servers": {
     "glider": {
       "command": "glider",
       "args": [

--- a/plugins/glidermcp/.codex-plugin/plugin.json
+++ b/plugins/glidermcp/.codex-plugin/plugin.json
@@ -18,7 +18,7 @@
     "roslyn"
   ],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json",
+  "mcpServers": "./.codex-mcp.json",
   "interface": {
     "displayName": "GliderMCP",
     "shortDescription": "C# semantic navigation for coding agents",

--- a/plugins/glidermcp/.codex-plugin/plugin.json
+++ b/plugins/glidermcp/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "glidermcp",
+  "version": "0.1.0",
+  "description": "Connect coding agents to the local GliderMCP C# semantic analysis server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "csharp",
+    "dotnet",
+    "mcp",
+    "semantic-code-navigation",
+    "roslyn"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "GliderMCP",
+    "shortDescription": "C# semantic navigation for coding agents",
+    "longDescription": "Use GliderMCP to give Codex semantic C# navigation, references, implementations, diagnostics, call graphs, impact analysis, and previewable refactoring through a local MCP server.",
+    "developerName": "GliderMCP",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://glidermcp.com",
+    "defaultPrompt": [
+      "Use GliderMCP to load this C# solution, inspect diagnostics, and navigate symbols semantically before editing."
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/glidermcp/.mcp.json
+++ b/plugins/glidermcp/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "glider": {
+      "command": "glider",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/plugins/glidermcp/.mcp.json
+++ b/plugins/glidermcp/.mcp.json
@@ -1,4 +1,13 @@
 {
+  "mcpServers": {
+    "glider": {
+      "command": "glider",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  },
   "mcp_servers": {
     "glider": {
       "command": "glider",

--- a/plugins/glidermcp/.mcp.json
+++ b/plugins/glidermcp/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "mcpServers": {
+  "mcp_servers": {
     "glider": {
       "command": "glider",
       "args": [

--- a/plugins/glidermcp/README.md
+++ b/plugins/glidermcp/README.md
@@ -1,0 +1,11 @@
+# GliderMCP Plugin
+
+This plugin connects agent clients to a local GliderMCP C# semantic analysis server.
+
+Prerequisites:
+
+- .NET 10 SDK
+- `dotnet tool install --global glider`
+- `glider` available on `PATH`
+
+The bundled MCP config starts Glider over stdio with a 30 minute default async-tool timeout.

--- a/plugins/glidermcp/skills/glider-csharp/SKILL.md
+++ b/plugins/glidermcp/skills/glider-csharp/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: Use GliderMCP for C#/.NET navigation, diagnostics, references, call graphs, impact analysis, and safe refactoring.
+---
+
+# GliderMCP C# Workflow
+
+Use GliderMCP when working in a C# or .NET repository and the task needs semantic facts rather than plain text search.
+
+Start by checking `server_status`. If no workspace is loaded, call `load` with the relevant `.sln`, `.slnx`, or `.csproj`. Prefer `find_code` as the front door when the user asks to locate behavior by intent. Use `search_symbols`, `resolve_symbol`, or `get_symbol_at_position` before symbol-specific tools, and treat returned `symbolKey` values as opaque stable identities.
+
+For edits, gather evidence first with tools such as `find_references`, `find_implementations`, `find_callers`, `get_outgoing_calls`, `analyze_change_impact`, `get_cascade_impact`, `get_diagnostics`, and `diagnostic_hotspots`. Prefer preview-first refactoring tools where available. After external edits, use `sync` for changed `.cs` files and `reload` for structural project changes.
+
+Use shell text search only for non-C# assets, literal strings, config files, or when a semantic tool cannot answer the question.


### PR DESCRIPTION
## Summary
- add root Claude Code marketplace at .claude-plugin/marketplace.json
- add root Codex marketplace at .agents/plugins/marketplace.json
- add shared GliderMCP plugin bundle and direct MCP config templates

## Validation
- parsed all JSON marketplace/plugin/MCP files with Node
- git diff --check