### PR TITLE
feat(repo): add glider-trace and tglider plugin bundles

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -17,6 +17,32 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "glider-trace",
+      "description": "Runtime evidence, command and test runs, exception summaries, counters, traces, dumps, and artifact indexing for Codex.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/glider-trace"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    },
+    {
+      "name": "tglider",
+      "description": "TypeScript and JavaScript semantic navigation, diagnostics, references, dependency topology, and refactoring for Codex.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/tglider"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,6 +10,16 @@
       "name": "glidermcp",
       "source": "./plugins/glidermcp",
       "description": "C# semantic navigation, diagnostics, references, call graphs, impact analysis, and safe refactoring for Claude Code."
+    },
+    {
+      "name": "glider-trace",
+      "source": "./plugins/glider-trace",
+      "description": "Runtime evidence, command and test runs, exception summaries, counters, traces, dumps, and artifact indexing for Claude Code."
+    },
+    {
+      "name": "tglider",
+      "source": "./plugins/tglider",
+      "description": "TypeScript and JavaScript semantic navigation, diagnostics, references, dependency topology, and refactoring for Claude Code."
     }
   ]
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,9 +9,9 @@ body:
       description: Which product is affected?
       options:
         - glider
+        - glider-trace
+        - tglider
         - glidermcp-web
-        - tsglider
-        - glider-memory
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,9 +8,9 @@ body:
       label: Product
       options:
         - glider
+        - glider-trace
+        - tglider
         - glidermcp-web
-        - tsglider
-        - glider-memory
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,9 +8,9 @@ body:
       label: Product
       options:
         - glider
+        - glider-trace
+        - tglider
         - glidermcp-web
-        - tsglider
-        - glider-memory
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -23,24 +23,28 @@ Please open issues in this repository and select the relevant product in the iss
 
 - Product site: https://glidermcp.com
 - Glider NuGet package: https://www.nuget.org/packages/glider
-- GliderTrace Nuget Package: https://www.nuget.org/packages/glider-trace
+- GliderTrace NuGet package: https://www.nuget.org/packages/glider-trace
 - TGlider NPM package: https://www.npmjs.com/package/tglider
 
 ## Plugin and config assets
 
 This repository ships root-level marketplace and config assets for agent clients:
 
-- `plugins/glidermcp/` - shared plugin bundle with `.mcp.json` plus a C# workflow skill.
+- `plugins/glidermcp/` - C# semantic navigation plugin.
+- `plugins/glider-trace/` - .NET runtime evidence plugin.
+- `plugins/tglider/` - TypeScript and JavaScript semantic navigation plugin.
 - `.claude-plugin/marketplace.json` - Claude Code marketplace entry.
 - `.agents/plugins/marketplace.json` - Codex marketplace entry.
 - `install/claude-code/.mcp.json` - direct Claude Code project config template.
-- `install/codex/config.toml` - direct Codex global config snippet for HTTP transport.
+- `install/codex/config.toml` - direct Codex global config snippet.
 
 Claude Code plugin install:
 
 ```bash
 claude plugin marketplace add glidermcp/glidermcp.com
 claude plugin install glidermcp@glidermcp
+claude plugin install glider-trace@glidermcp
+claude plugin install tglider@glidermcp
 ```
 
 Codex plugin install:
@@ -48,7 +52,7 @@ Codex plugin install:
 ```bash
 codex plugin marketplace add glidermcp/glidermcp.com
 codex
-# Open /plugins and install glidermcp.
+# Open /plugins and install glidermcp, glider-trace, or tglider.
 ```
 
 ## Notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,6 @@ Open a new issue in this repository titled `Security report: <short summary>` wi
 
 Include:
 
-- affected product (`glider`, `glidermcp-web`, `tsglider`, `glider-memory`)
+- affected product (`glider`, `glider-trace`, `tglider`, `glidermcp-web`)
 - affected version
 - high-level impact

--- a/install/README.md
+++ b/install/README.md
@@ -6,12 +6,14 @@ Prerequisites:
 
 - .NET 10 SDK
 - `dotnet tool install --global glider`
-- `glider` available on `PATH`
+- `dotnet tool install --global glider-trace`
+- Node.js/npm for `npx -y tglider`
+- `glider`, `glider-trace`, and `npx` available on `PATH`
 
 Templates:
 
 - `claude-code/.mcp.json` - project-scoped Claude Code MCP config.
-- `codex/config.toml` - Codex global config snippet for Streamable HTTP.
+- `codex/config.toml` - Codex global config snippet.
 
 Plugin marketplace setup is also available from this repository:
 
@@ -19,13 +21,9 @@ Plugin marketplace setup is also available from this repository:
 # Claude Code
 claude plugin marketplace add glidermcp/glidermcp.com
 claude plugin install glidermcp@glidermcp
+claude plugin install glider-trace@glidermcp
+claude plugin install tglider@glidermcp
 
 # Codex
 codex plugin marketplace add glidermcp/glidermcp.com
-```
-
-For Codex direct config, start Glider separately with:
-
-```bash
-glider --transport http --default-timeout 30m
 ```

--- a/install/claude-code/.mcp.json
+++ b/install/claude-code/.mcp.json
@@ -6,6 +6,22 @@
         "--default-timeout",
         "30m"
       ]
+    },
+    "glider-trace": {
+      "command": "glider-trace",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    },
+    "tglider": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "tglider",
+        "--default-timeout",
+        "30m"
+      ]
     }
   }
 }

--- a/install/codex/config.toml
+++ b/install/codex/config.toml
@@ -1,8 +1,17 @@
 [mcp_servers.glider]
-url = "http://localhost:5001/mcp"
-http_headers = { Accept = "application/json, text/event-stream" }
+command = "glider"
+args = ["--default-timeout", "30m"]
 startup_timeout_sec = 30
 tool_timeout_sec = 1200
 
-# Start separately:
-# glider --transport http --default-timeout 30m
+[mcp_servers."glider-trace"]
+command = "glider-trace"
+args = ["--default-timeout", "30m"]
+startup_timeout_sec = 30
+tool_timeout_sec = 1200
+
+[mcp_servers.tglider]
+command = "npx"
+args = ["-y", "tglider", "--default-timeout", "30m"]
+startup_timeout_sec = 30
+tool_timeout_sec = 1200

--- a/plugins/glider-trace/.claude-plugin/plugin.json
+++ b/plugins/glider-trace/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "glider-trace",
+  "description": "Connect coding agents to the local GliderTrace runtime evidence MCP server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "csharp",
+    "dotnet",
+    "mcp",
+    "runtime-evidence",
+    "test-evidence"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/glider-trace/.codex-mcp.json
+++ b/plugins/glider-trace/.codex-mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcp_servers": {
+    "glider-trace": {
+      "command": "glider-trace",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/plugins/glider-trace/.codex-plugin/plugin.json
+++ b/plugins/glider-trace/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "glider-trace",
+  "version": "0.1.0",
+  "description": "Connect coding agents to the local GliderTrace runtime evidence MCP server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "csharp",
+    "dotnet",
+    "mcp",
+    "runtime-evidence",
+    "test-evidence"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.codex-mcp.json",
+  "interface": {
+    "displayName": "GliderTrace",
+    "shortDescription": ".NET runtime evidence for coding agents",
+    "longDescription": "Use GliderTrace to give Codex captured evidence from .NET commands, tests, failures, exceptions, counters, traces, dumps, and local artifacts through a runtime-focused MCP server.",
+    "developerName": "GliderMCP",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://glidermcp.com",
+    "defaultPrompt": [
+      "Use GliderTrace to collect runtime evidence before diagnosing .NET failures or test behavior."
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/glider-trace/.mcp.json
+++ b/plugins/glider-trace/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "glider-trace": {
+      "command": "glider-trace",
+      "args": [
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/plugins/glider-trace/README.md
+++ b/plugins/glider-trace/README.md
@@ -1,0 +1,11 @@
+# GliderTrace Plugin
+
+This plugin connects agent clients to a local GliderTrace runtime evidence MCP server.
+
+Prerequisites:
+
+- .NET 10 SDK
+- `dotnet tool install --global glider-trace`
+- `glider-trace` available on `PATH`
+
+The bundled MCP config starts GliderTrace over stdio with a 30 minute default async-tool timeout.

--- a/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
+++ b/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: glider-trace-runtime
+description: Use GliderTrace for .NET runtime evidence, test runs, failure summaries, exceptions, counters, traces, dumps, and artifact indexing.
+---
+
+# GliderTrace Runtime Evidence Workflow
+
+Use GliderTrace when working in a C# or .NET repository and the task needs runtime evidence rather than static source inspection alone.
+
+Prefer GliderTrace for test runs, command runs, failure summaries, exception and stack evidence, stdout/stderr summaries, counters, traces, dumps, GC dumps, and artifact indexing. Use `trace_status` first when you need to confirm server state, workspace, artifact root, allowed commands, and local dependency availability.
+
+For investigations, run commands through trace tools so stdout, stderr, exit status, timings, findings, and artifacts remain connected to one session. Use test-specific tools for .NET test evidence, and query/export session artifacts when summarizing the failure or handing evidence back to the user.
+
+Use plain shell commands only for simple file operations or when captured runtime evidence is not useful.

--- a/plugins/tglider/.claude-plugin/plugin.json
+++ b/plugins/tglider/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "tglider",
+  "description": "Connect coding agents to the local TGlider TypeScript and JavaScript semantic MCP server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "javascript",
+    "mcp",
+    "semantic-code-navigation",
+    "refactoring"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/tglider/.codex-mcp.json
+++ b/plugins/tglider/.codex-mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcp_servers": {
+    "tglider": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "tglider",
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/plugins/tglider/.codex-plugin/plugin.json
+++ b/plugins/tglider/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "tglider",
+  "version": "0.1.0",
+  "description": "Connect coding agents to the local TGlider TypeScript and JavaScript semantic MCP server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "typescript",
+    "javascript",
+    "mcp",
+    "semantic-code-navigation",
+    "refactoring"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.codex-mcp.json",
+  "interface": {
+    "displayName": "TGlider",
+    "shortDescription": "TypeScript and JavaScript semantic navigation for coding agents",
+    "longDescription": "Use TGlider to give Codex semantic TypeScript and JavaScript navigation, references, implementations, diagnostics, dependency topology, impact analysis, and previewable refactoring through a local MCP server.",
+    "developerName": "GliderMCP",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://glidermcp.com",
+    "defaultPrompt": [
+      "Use TGlider to load this TypeScript or JavaScript workspace and navigate symbols semantically before editing."
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/tglider/.mcp.json
+++ b/plugins/tglider/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "tglider": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "tglider",
+        "--default-timeout",
+        "30m"
+      ]
+    }
+  }
+}

--- a/plugins/tglider/README.md
+++ b/plugins/tglider/README.md
@@ -1,0 +1,10 @@
+# TGlider Plugin
+
+This plugin connects agent clients to a local TGlider TypeScript and JavaScript semantic MCP server.
+
+Prerequisites:
+
+- Node.js/npm
+- `npx` available on `PATH`
+
+The bundled MCP config starts TGlider over stdio with `npx -y tglider` and a 30 minute default async-tool timeout.

--- a/plugins/tglider/skills/tglider-typescript/SKILL.md
+++ b/plugins/tglider/skills/tglider-typescript/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: tglider-typescript
+description: Use TGlider for TypeScript and JavaScript semantic navigation, references, diagnostics, dependency topology, impact analysis, and refactoring.
+---
+
+# TGlider TypeScript Workflow
+
+Use TGlider when working in a TypeScript or JavaScript repository and the task needs semantic facts rather than plain text search.
+
+Start by loading the relevant workspace when needed. Prefer semantic symbol, reference, export, diagnostic, hierarchy, call graph, impact, and dependency tools before reading source text. Use source reads only for bounded context after the semantic tools identify the relevant files or symbols.
+
+For edits, gather evidence first with tools for references, callers, outgoing calls, diagnostics, dependency topology, and change impact. Prefer preview-first refactoring tools where available, and refresh diagnostics after meaningful edits.
+
+Use shell text search only for non-code assets, generated output, literal config files, or when a semantic tool cannot answer the question.


### PR DESCRIPTION
## Summary
- Adds standalone marketplace/plugin assets for `glider-trace` and `tglider` in addition to existing `glidermcp`.
- Updates `.agents/plugins/marketplace.json` and `.claude-plugin/marketplace.json` to list all three plugins.
- Adds plugin manifests, `.mcp.json` configs, install docs, and focused workflow skills for both new plugins.
- Updates issue/security/public docs to reflect current product names (`glider-trace`, `tglider`) and remove `tsglider/glider-memory` routing options.

## Validation
- JSON parse checks for updated manifests.
- TOML parse check for `install/codex/config.toml`.
- Package fact checks: `npm view tglider`, `dotnet tool search glider-trace`.
- Smoke checks: `npx -y tglider --help`, `glider-trace --help`.

## Risks
- No functional runtime code changes in this repo; this is plugin metadata/installation surface only.
