### PR TITLE
feat(repo): add scout plugin bundle

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -43,6 +43,19 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "scout",
+      "description": "Universal read-only code search over any repository and any language - ranked fuzzy discovery and exhaustive strict search from a resident index, for Codex.",
+      "source": {
+        "source": "local",
+        "path": "./plugins/scout"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "glidermcp",
+  "description": "GliderMCP plugins for coding agents.",
   "owner": {
     "name": "GliderMCP",
     "email": "feedback@glidermcp.com",
@@ -20,6 +21,11 @@
       "name": "tglider",
       "source": "./plugins/tglider",
       "description": "TypeScript and JavaScript semantic navigation, diagnostics, references, dependency topology, and refactoring for Claude Code."
+    },
+    {
+      "name": "scout",
+      "source": "./plugins/scout",
+      "description": "Universal read-only code search over any repository and any language - ranked fuzzy discovery and exhaustive strict search from a resident index, for Claude Code."
     }
   ]
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,7 @@ body:
         - glider
         - glider-trace
         - tglider
+        - scout
         - glidermcp-web
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,6 +10,7 @@ body:
         - glider
         - glider-trace
         - tglider
+        - scout
         - glidermcp-web
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,6 +10,7 @@ body:
         - glider
         - glider-trace
         - tglider
+        - scout
         - glidermcp-web
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ Please open issues in this repository and select the relevant product in the iss
 - `glider` (C# MCP)
 - `glider-trace` (runtime evidence MCP server)
 - `tglider` (TypeScript MCP)
+- `scout` (universal code search MCP)
 - `glidermcp-web` (website/docs UX)
 
 ## Quick links
 
 - Product site: https://glidermcp.com
-- Glider NuGet package: https://www.nuget.org/packages/glider
-- GliderTrace NuGet package: https://www.nuget.org/packages/glider-trace
-- TGlider NPM package: https://www.npmjs.com/package/tglider
+- Glider: https://glidermcp.com/glider - https://www.nuget.org/packages/glider
+- GliderTrace: https://glidermcp.com/glider-trace - https://www.nuget.org/packages/glider-trace
+- TGlider: https://glidermcp.com/tglider - https://www.npmjs.com/package/tglider
+- Scout: https://glidermcp.com/scout - https://www.npmjs.com/package/@glidermcp/scout
 
 ## Plugin and config assets
 
@@ -33,6 +35,7 @@ This repository ships root-level marketplace and config assets for agent clients
 - `plugins/glidermcp/` - C# semantic navigation plugin.
 - `plugins/glider-trace/` - .NET runtime evidence plugin.
 - `plugins/tglider/` - TypeScript and JavaScript semantic navigation plugin.
+- `plugins/scout/` - universal code search plugin.
 - `.claude-plugin/marketplace.json` - Claude Code marketplace entry.
 - `.agents/plugins/marketplace.json` - Codex marketplace entry.
 - `install/claude-code/.mcp.json` - direct Claude Code project config template.
@@ -45,6 +48,7 @@ claude plugin marketplace add glidermcp/glidermcp.com
 claude plugin install glidermcp@glidermcp
 claude plugin install glider-trace@glidermcp
 claude plugin install tglider@glidermcp
+claude plugin install scout@glidermcp
 ```
 
 Codex plugin install:
@@ -52,7 +56,7 @@ Codex plugin install:
 ```bash
 codex plugin marketplace add glidermcp/glidermcp.com
 codex
-# Open /plugins and install glidermcp, glider-trace, or tglider.
+# Open /plugins and install glidermcp, glider-trace, tglider, or scout.
 ```
 
 ## Notes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,6 @@ Open a new issue in this repository titled `Security report: <short summary>` wi
 
 Include:
 
-- affected product (`glider`, `glider-trace`, `tglider`, `glidermcp-web`)
+- affected product (`glider`, `glider-trace`, `tglider`, `scout`, `glidermcp-web`)
 - affected version
 - high-level impact

--- a/install/README.md
+++ b/install/README.md
@@ -7,8 +7,14 @@ Prerequisites:
 - .NET 10 SDK
 - `dotnet tool install --global glider`
 - `dotnet tool install --global glider-trace`
-- Node.js/npm for `npx -y tglider`
+- Node.js/npm for `npx -y tglider` and `npx -y @glidermcp/scout`
 - `glider`, `glider-trace`, and `npx` available on `PATH`
+
+Scout also belongs on `PATH` as a real binary, not only as an `npx` MCP entry. Glider and TGlider delegate `search_text` to a global `scout` - Glider upgrades from loaded C# documents to every file under its solution root in any language, and TGlider needs Scout for `search_text` at all:
+
+```bash
+npm install -g @glidermcp/scout
+```
 
 Templates:
 
@@ -23,6 +29,7 @@ claude plugin marketplace add glidermcp/glidermcp.com
 claude plugin install glidermcp@glidermcp
 claude plugin install glider-trace@glidermcp
 claude plugin install tglider@glidermcp
+claude plugin install scout@glidermcp
 
 # Codex
 codex plugin marketplace add glidermcp/glidermcp.com

--- a/install/claude-code/.mcp.json
+++ b/install/claude-code/.mcp.json
@@ -22,6 +22,13 @@
         "--default-timeout",
         "30m"
       ]
+    },
+    "scout": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@glidermcp/scout"
+      ]
     }
   }
 }

--- a/install/codex/config.toml
+++ b/install/codex/config.toml
@@ -15,3 +15,9 @@ command = "npx"
 args = ["-y", "tglider", "--default-timeout", "30m"]
 startup_timeout_sec = 30
 tool_timeout_sec = 1200
+
+[mcp_servers.scout]
+command = "npx"
+args = ["-y", "@glidermcp/scout"]
+startup_timeout_sec = 30
+tool_timeout_sec = 60

--- a/plugins/glider-trace/.claude-plugin/plugin.json
+++ b/plugins/glider-trace/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "glider-trace",
-  "version": "0.1.0",
   "description": "Connect coding agents to the local GliderTrace runtime evidence MCP server.",
   "author": {
     "name": "GliderMCP",

--- a/plugins/glider-trace/.codex-plugin/plugin.json
+++ b/plugins/glider-trace/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com",
+  "homepage": "https://glidermcp.com/glider-trace",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [
@@ -29,7 +29,7 @@
       "Interactive",
       "Write"
     ],
-    "websiteURL": "https://glidermcp.com",
+    "websiteURL": "https://glidermcp.com/glider-trace",
     "defaultPrompt": [
       "Use GliderTrace to collect runtime evidence before diagnosing .NET failures or test behavior."
     ],

--- a/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
+++ b/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
@@ -11,4 +11,4 @@ Prefer GliderTrace for test runs, command runs, failure summaries, exception and
 
 For investigations, run commands through trace tools so stdout, stderr, exit status, timings, findings, and artifacts remain connected to one session. Use test-specific tools for .NET test evidence, and query/export session artifacts when summarizing the failure or handing evidence back to the user.
 
-Use plain shell commands only for simple file operations or when captured runtime evidence is not useful.
+When an investigation needs to locate code, logs, or artifacts by text across the repository, use Scout's `find` rather than shell search. Use plain shell commands only for simple file operations or when captured runtime evidence is not useful.

--- a/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
+++ b/plugins/glider-trace/skills/glider-trace-runtime/SKILL.md
@@ -11,4 +11,4 @@ Prefer GliderTrace for test runs, command runs, failure summaries, exception and
 
 For investigations, run commands through trace tools so stdout, stderr, exit status, timings, findings, and artifacts remain connected to one session. Use test-specific tools for .NET test evidence, and query/export session artifacts when summarizing the failure or handing evidence back to the user.
 
-When an investigation needs to locate code, logs, or artifacts by text across the repository, use Scout's `find` rather than shell search. Use plain shell commands only for simple file operations or when captured runtime evidence is not useful.
+When an investigation needs to locate code, logs, or artifacts by text across the repository, prefer Scout's `find` if Scout is installed, and fall back to shell search when it is not. Use plain shell commands only for simple file operations or when captured runtime evidence is not useful.

--- a/plugins/glidermcp/.claude-plugin/plugin.json
+++ b/plugins/glidermcp/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "glidermcp",
+  "version": "0.1.0",
   "description": "Connect coding agents to the local GliderMCP C# semantic analysis server.",
   "author": {
     "name": "GliderMCP",
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com",
+  "homepage": "https://glidermcp.com/glider",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [

--- a/plugins/glidermcp/.claude-plugin/plugin.json
+++ b/plugins/glidermcp/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "glidermcp",
-  "version": "0.1.0",
   "description": "Connect coding agents to the local GliderMCP C# semantic analysis server.",
   "author": {
     "name": "GliderMCP",

--- a/plugins/glidermcp/.codex-plugin/plugin.json
+++ b/plugins/glidermcp/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com",
+  "homepage": "https://glidermcp.com/glider",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [
@@ -29,7 +29,7 @@
       "Interactive",
       "Write"
     ],
-    "websiteURL": "https://glidermcp.com",
+    "websiteURL": "https://glidermcp.com/glider",
     "defaultPrompt": [
       "Use GliderMCP to load this C# solution, inspect diagnostics, and navigate symbols semantically before editing."
     ],

--- a/plugins/glidermcp/skills/glider-csharp/SKILL.md
+++ b/plugins/glidermcp/skills/glider-csharp/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: glider-csharp
 description: Use GliderMCP for C#/.NET navigation, diagnostics, references, call graphs, impact analysis, and safe refactoring.
 ---
 
@@ -10,4 +11,4 @@ Start by checking `server_status`. If no workspace is loaded, call `load` with t
 
 For edits, gather evidence first with tools such as `find_references`, `find_implementations`, `find_callers`, `get_outgoing_calls`, `analyze_change_impact`, `get_cascade_impact`, `get_diagnostics`, and `diagnostic_hotspots`. Prefer preview-first refactoring tools where available. After external edits, use `sync` for changed `.cs` files and `reload` for structural project changes.
 
-Use shell text search only for non-C# assets, literal strings, config files, or when a semantic tool cannot answer the question.
+For non-C# assets, literal strings, config files, and repo-wide text search, prefer Scout's `find` when Scout is installed. Glider's own `search_text` already delegates to Scout when a `scout` binary is on `PATH`, and reports which backend answered in `data.backend` - `scout` covers every file under the solution root in any language, `workspace` covers only loaded C# documents. Use shell text search only when neither can answer the question.

--- a/plugins/scout/.claude-plugin/plugin.json
+++ b/plugins/scout/.claude-plugin/plugin.json
@@ -1,21 +1,21 @@
 {
-  "name": "glider-trace",
+  "name": "scout",
   "version": "0.1.0",
-  "description": "Connect coding agents to the local GliderTrace runtime evidence MCP server.",
+  "description": "Connect coding agents to the local Scout universal code search MCP server.",
   "author": {
     "name": "GliderMCP",
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com/glider-trace",
+  "homepage": "https://glidermcp.com/scout",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [
-    "csharp",
-    "dotnet",
+    "code-search",
     "mcp",
-    "runtime-evidence",
-    "test-evidence"
+    "grep",
+    "fuzzy-search",
+    "code-intelligence"
   ],
   "skills": "./skills/"
 }

--- a/plugins/scout/.claude-plugin/plugin.json
+++ b/plugins/scout/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "scout",
-  "version": "0.1.0",
   "description": "Connect coding agents to the local Scout universal code search MCP server.",
   "author": {
     "name": "GliderMCP",

--- a/plugins/scout/.codex-mcp.json
+++ b/plugins/scout/.codex-mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcp_servers": {
+    "scout": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@glidermcp/scout"
+      ]
+    }
+  }
+}

--- a/plugins/scout/.codex-plugin/plugin.json
+++ b/plugins/scout/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "scout",
+  "version": "0.1.0",
+  "description": "Connect coding agents to the local Scout universal code search MCP server.",
+  "author": {
+    "name": "GliderMCP",
+    "email": "feedback@glidermcp.com",
+    "url": "https://glidermcp.com"
+  },
+  "homepage": "https://glidermcp.com/scout",
+  "repository": "https://github.com/glidermcp/glidermcp.com",
+  "license": "MIT",
+  "keywords": [
+    "code-search",
+    "mcp",
+    "grep",
+    "fuzzy-search",
+    "code-intelligence"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.codex-mcp.json",
+  "interface": {
+    "displayName": "Scout",
+    "shortDescription": "Universal code search for coding agents",
+    "longDescription": "Use Scout to give Codex ranked fuzzy search and exhaustive strict search over any repository in any language, from a resident watcher-fresh index, with no project configuration.",
+    "developerName": "GliderMCP",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive"
+    ],
+    "websiteURL": "https://glidermcp.com/scout",
+    "defaultPrompt": [
+      "Use Scout to search this repository for the relevant code before reading files."
+    ],
+    "screenshots": []
+  }
+}

--- a/plugins/scout/.mcp.json
+++ b/plugins/scout/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "scout": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@glidermcp/scout"
+      ]
+    }
+  }
+}

--- a/plugins/scout/README.md
+++ b/plugins/scout/README.md
@@ -1,0 +1,22 @@
+# Scout Plugin
+
+This plugin connects agent clients to a local Scout universal code search MCP server.
+
+Prerequisites:
+
+- Node.js/npm
+- `npx` available on `PATH`
+
+The bundled MCP config starts Scout over stdio with `npx -y @glidermcp/scout`.
+
+## Also install Scout globally
+
+The bundled `npx` entry gives the agent Scout's `find` tool, but it leaves no `scout` binary on `PATH`. A real binary on `PATH` is what lets Glider and TGlider delegate `search_text` to Scout - Glider upgrades from loaded C# documents to every file under its solution root in any language, and TGlider needs Scout for `search_text` at all (without it the tool returns a `scout_not_installed` hint).
+
+```sh
+npm install -g @glidermcp/scout
+curl -fsSL https://glidermcp.com/install.sh | sh   # Linux/macOS, installs to ~/.local/bin
+brew install glidermcp/tap/scout                   # macOS/Linux
+```
+
+The install script does not edit `PATH`. If `~/.local/bin` is not already on it, add it, or point at the binary with `SCOUT_BINARY_PATH`. With Scout installed globally you can also swap the bundled config to `"command": "scout"` with no args. Turn the delegation off with `--no-scout` or `GLIDERMCP_NO_SCOUT=1`.

--- a/plugins/scout/skills/scout-search/SKILL.md
+++ b/plugins/scout/skills/scout-search/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: scout-search
+description: Use Scout for repo-wide code search in any language - ranked fuzzy discovery, exhaustive strict literal, regex, and word search, plus structural patterns, symbol outlines, and semantic queries.
+---
+
+# Scout Code Search Workflow
+
+Use Scout's `find` as the primary workspace search instead of shell `grep`, `rg`, or `find`. If Glider (C#) or TGlider (TypeScript and JavaScript) is installed, prefer it for its language, and use Scout for every other language and as the universal fallback.
+
+`target: auto` routes by query shape, and every response echoes the resolved route in `data.route`. Use strict `match` modes - `literal`, `regex`, or `word` - when you need exhaustive grep semantics for an audit or a rename survey; fuzzy is ranked top-N with frecency and is never exhaustive. A zero-hit strict search returns an honest empty result rather than silently falling back, so treat it as evidence. Use `target: structural` for ast-grep patterns (`$NAME` for one node, `$$$` for many), `target: symbols` for a tree-sitter declaration outline, and `target: semantic` for natural-language questions. Outside a shipped grammar, or without a semantic model, these degrade to lexical search and say so in `meta.degraded` - check `server_status.tiers` before relying on them.
+
+Narrow with path prefixes, include and exclude globs, and language scoping before widening the query, and page through results instead of loosening the match. Results carry workspace-relative paths, 1-based line and column, and trimmed previews, never whole files. Use `server_status` for index, watcher, and tier health, and `sync {full: true}` only to force a full rescan, since ordinary queries already flush pending changes.
+
+Scout never mutates workspace source - its only writes are its own state under `.glider/scout/` and `~/.glidermcp`. When a hit needs semantic follow-up or an edit, hand the file and span to Glider for C#, or TGlider for TypeScript and JavaScript.

--- a/plugins/tglider/.claude-plugin/plugin.json
+++ b/plugins/tglider/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "tglider",
-  "version": "0.1.0",
   "description": "Connect coding agents to the local TGlider TypeScript and JavaScript semantic MCP server.",
   "author": {
     "name": "GliderMCP",

--- a/plugins/tglider/.claude-plugin/plugin.json
+++ b/plugins/tglider/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "tglider",
+  "version": "0.1.0",
   "description": "Connect coding agents to the local TGlider TypeScript and JavaScript semantic MCP server.",
   "author": {
     "name": "GliderMCP",
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com",
+  "homepage": "https://glidermcp.com/tglider",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [

--- a/plugins/tglider/.codex-plugin/plugin.json
+++ b/plugins/tglider/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "feedback@glidermcp.com",
     "url": "https://glidermcp.com"
   },
-  "homepage": "https://glidermcp.com",
+  "homepage": "https://glidermcp.com/tglider",
   "repository": "https://github.com/glidermcp/glidermcp.com",
   "license": "MIT",
   "keywords": [
@@ -29,7 +29,7 @@
       "Interactive",
       "Write"
     ],
-    "websiteURL": "https://glidermcp.com",
+    "websiteURL": "https://glidermcp.com/tglider",
     "defaultPrompt": [
       "Use TGlider to load this TypeScript or JavaScript workspace and navigate symbols semantically before editing."
     ],

--- a/plugins/tglider/skills/tglider-typescript/SKILL.md
+++ b/plugins/tglider/skills/tglider-typescript/SKILL.md
@@ -11,4 +11,4 @@ Start by loading the relevant workspace when needed. Prefer semantic symbol, ref
 
 For edits, gather evidence first with tools for references, callers, outgoing calls, diagnostics, dependency topology, and change impact. Prefer preview-first refactoring tools where available, and refresh diagnostics after meaningful edits.
 
-For non-code assets, generated output, literal config files, and repo-wide text search, prefer Scout's `find`. TGlider's own `search_text` searches with Scout and requires it - without a `scout` binary on `PATH` it returns a `scout_not_installed` hint, so install Scout globally to use that tool at all. Use shell text search only when neither can answer the question.
+For non-code assets, generated output, literal config files, and repo-wide text search, prefer Scout's `find` when Scout is installed. TGlider's own `search_text` searches with Scout and requires it - without a `scout` binary on `PATH` it returns a `scout_not_installed` hint, so install Scout globally to use that tool at all. Use shell text search when Scout is absent, or when neither can answer the question.

--- a/plugins/tglider/skills/tglider-typescript/SKILL.md
+++ b/plugins/tglider/skills/tglider-typescript/SKILL.md
@@ -11,4 +11,4 @@ Start by loading the relevant workspace when needed. Prefer semantic symbol, ref
 
 For edits, gather evidence first with tools for references, callers, outgoing calls, diagnostics, dependency topology, and change impact. Prefer preview-first refactoring tools where available, and refresh diagnostics after meaningful edits.
 
-Use shell text search only for non-code assets, generated output, literal config files, or when a semantic tool cannot answer the question.
+For non-code assets, generated output, literal config files, and repo-wide text search, prefer Scout's `find`. TGlider's own `search_text` searches with Scout and requires it - without a `scout` binary on `PATH` it returns a `scout_not_installed` hint, so install Scout globally to use that tool at all. Use shell text search only when neither can answer the question.


### PR DESCRIPTION
## Why

<https://glidermcp.com/scout/installation/claude-code> already publishes this:

```
/plugin marketplace add glidermcp/glidermcp.com
/plugin install scout@glidermcp
```

The second line fails today — this marketplace has no `scout` entry. The web content calls `claudePluginStep('Scout', 'scout')`, so the docs have been promising a plugin that was never shipped. This adds it, and registers scout everywhere the other three products already appear.

## What changed

**New `plugins/scout/`** — mirrors `plugins/tglider/` exactly (verified on file shape). `.mcp.json` / `.codex-mcp.json` launch `npx -y @glidermcp/scout`, with **no `--default-timeout`** — that's a glider/tglider flag, and `scout` rejects unknown args.

**`skills/scout-search/SKILL.md`** is derived from `SERVER_INSTRUCTIONS` in `scout-server/src/instructions.rs`, not from the marketing pages. Scout 0.3.0's `find` has four targets (`auto`/`structural`/`symbols`/`semantic`) plus `match: literal|regex|word`; a lexical-only paraphrase would have under-sold the tool.

**Consistency pass across the family:**

- All three existing skills now route repo-wide text search to scout's `find` ahead of shell `grep`/`rg`/`find`
- Each plugin's `homepage` and Codex `websiteURL` moves off the site root to its own product page — `/glider`, `/glider-trace`, `/tglider`, `/scout` (all verified 200; the site 404s correctly, so these aren't SPA false positives)
- `version` added to the four `.claude-plugin/plugin.json` files, which their `.codex-plugin` twins already declared as `0.1.0`, plus a marketplace `description`
- Missing `name` frontmatter key added to the `glider-csharp` skill — the only one of the three lacking it
- scout listed in `README.md`, `SECURITY.md`, both install templates, and the three issue-template product dropdowns

## For reviewers

**The npx / PATH tradeoff is the one real design decision here.** An `npx` MCP entry leaves no `scout` binary on `PATH` — and per `product-agent-guidance.ts`, that binary is what lets Glider and TGlider delegate `search_text`. **TGlider's `search_text` returns `scout_not_installed` without it** (`required: true`), while Glider degrades gracefully (`required: false`).

So `/plugin install scout@glidermcp` hands you the `find` tool but does *not* fix TGlider's search. Shipping `"command": "scout"` instead was considered and rejected: it fails to start for anyone who hasn't already installed globally, with no in-client hint why. Instead the plugin ships npx (works everywhere, zero setup, matches the published config) and both `plugins/scout/README.md` and the tglider skill state the gap explicitly and point at `npm install -g @glidermcp/scout`.

Two deliberate deviations from the sibling plugins:

- **`capabilities: ["Interactive"]`**, dropping the `"Write"` the other three declare — scout never mutates workspace source; its only writes are `.glider/scout/` and `~/.glidermcp`.
- **`tool_timeout_sec = 60`** in the Codex template, not the `1200` its three neighbours use. Scout answers in milliseconds and <https://glidermcp.com/scout/installation/codex> publishes `60`.

## Verification

- `claude plugin validate` passes clean on the marketplace and all four plugin manifests (was 5 warnings before the `version`/`description` additions)
- `npx -y @glidermcp/scout --version` → `scout 0.3.0`, matching `.mcp/server.json` in the monorepo
- All JSON parses; issue-template YAML dropdowns confirmed; `plugins/scout/` file shape diffed against `plugins/tglider/`

A companion change in the private monorepo adds Scout to the support page, adds the plugin-step caveat to `product-agent-guidance.ts`, and adds `products/rust` to the README structure block — it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
