### PR TITLE
fix(repo): launch the scout plugin from a PATH binary, not npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ This repository ships root-level marketplace and config assets for agent clients
 - `install/claude-code/.mcp.json` - direct Claude Code project config template.
 - `install/codex/config.toml` - direct Codex global config snippet.
 
+Every plugin launches a server that must already be on `PATH`:
+
+```bash
+dotnet tool install --global glider          # glidermcp plugin
+dotnet tool install --global glider-trace    # glider-trace plugin
+npm install -g @glidermcp/scout              # scout plugin
+# tglider runs via npx and needs only Node.js/npm
+```
+
+Scout in particular has to be a real binary rather than an `npx` entry: `PATH` is how Glider and TGlider find it to delegate `search_text`. See `plugins/scout/README.md`.
+
 Claude Code plugin install:
 
 ```bash

--- a/install/README.md
+++ b/install/README.md
@@ -7,10 +7,11 @@ Prerequisites:
 - .NET 10 SDK
 - `dotnet tool install --global glider`
 - `dotnet tool install --global glider-trace`
-- Node.js/npm for `npx -y tglider` and `npx -y @glidermcp/scout`
-- `glider`, `glider-trace`, and `npx` available on `PATH`
+- Node.js/npm for `npx -y tglider`
+- `npm install -g @glidermcp/scout` (or the install script / Homebrew tap)
+- `glider`, `glider-trace`, `scout`, and `npx` available on `PATH`
 
-Scout also belongs on `PATH` as a real binary, not only as an `npx` MCP entry. Glider and TGlider delegate `search_text` to a global `scout` - Glider upgrades from loaded C# documents to every file under its solution root in any language, and TGlider needs Scout for `search_text` at all:
+Scout has to be a real binary on `PATH`, not an `npx` MCP entry. `PATH` is how Glider and TGlider discover Scout to delegate `search_text` to it - Glider upgrades from loaded C# documents to every file under its solution root in any language, and TGlider needs Scout for `search_text` at all. Reached only through `npx`, Scout still serves its own `find` tool, but both delegations quietly stop working.
 
 ```bash
 npm install -g @glidermcp/scout

--- a/install/claude-code/.mcp.json
+++ b/install/claude-code/.mcp.json
@@ -24,11 +24,8 @@
       ]
     },
     "scout": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@glidermcp/scout"
-      ]
+      "command": "scout",
+      "args": []
     }
   }
 }

--- a/install/codex/config.toml
+++ b/install/codex/config.toml
@@ -17,7 +17,7 @@ startup_timeout_sec = 30
 tool_timeout_sec = 1200
 
 [mcp_servers.scout]
-command = "npx"
-args = ["-y", "@glidermcp/scout"]
+command = "scout"
+args = []
 startup_timeout_sec = 30
 tool_timeout_sec = 60

--- a/plugins/scout/.codex-mcp.json
+++ b/plugins/scout/.codex-mcp.json
@@ -1,11 +1,8 @@
 {
   "mcp_servers": {
     "scout": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@glidermcp/scout"
-      ]
+      "command": "scout",
+      "args": []
     }
   }
 }

--- a/plugins/scout/.mcp.json
+++ b/plugins/scout/.mcp.json
@@ -1,11 +1,8 @@
 {
   "mcpServers": {
     "scout": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@glidermcp/scout"
-      ]
+      "command": "scout",
+      "args": []
     }
   }
 }

--- a/plugins/scout/README.md
+++ b/plugins/scout/README.md
@@ -20,4 +20,8 @@ An `npx -y @glidermcp/scout` entry runs Scout fine on its own, but it leaves no 
 
 A global install also keeps one Scout version in play. An `npx` entry resolves the latest published version on each start, which can drift from whatever binary Glider federates to.
 
-The install script does not edit `PATH`. If `~/.local/bin` is not already on it, add it, or point at the binary with `SCOUT_BINARY_PATH`. Turn the delegation off with `--no-scout` or `GLIDERMCP_NO_SCOUT=1`.
+The install script does not edit `PATH`. If `~/.local/bin` is not already on your agent client's `PATH`, add it — this plugin launches the literal command `scout`, so a binary the client cannot find fails to start regardless of anything else. If you would rather not touch `PATH`, set the plugin's MCP `command` to the binary's absolute path instead.
+
+`SCOUT_BINARY_PATH` does not substitute for either: Glider and TGlider read it to locate Scout for delegation, but it is not consulted when your client spawns this plugin's own server. Use it for delegation-only setups, where Scout is not configured as an MCP server at all.
+
+Turn the delegation off with `--no-scout` or `GLIDERMCP_NO_SCOUT=1`.

--- a/plugins/scout/README.md
+++ b/plugins/scout/README.md
@@ -4,19 +4,20 @@ This plugin connects agent clients to a local Scout universal code search MCP se
 
 Prerequisites:
 
-- Node.js/npm
-- `npx` available on `PATH`
-
-The bundled MCP config starts Scout over stdio with `npx -y @glidermcp/scout`.
-
-## Also install Scout globally
-
-The bundled `npx` entry gives the agent Scout's `find` tool, but it leaves no `scout` binary on `PATH`. A real binary on `PATH` is what lets Glider and TGlider delegate `search_text` to Scout - Glider upgrades from loaded C# documents to every file under its solution root in any language, and TGlider needs Scout for `search_text` at all (without it the tool returns a `scout_not_installed` hint).
+- A `scout` binary on `PATH`:
 
 ```sh
-npm install -g @glidermcp/scout
-curl -fsSL https://glidermcp.com/install.sh | sh   # Linux/macOS, installs to ~/.local/bin
-brew install glidermcp/tap/scout                   # macOS/Linux
+npm install -g @glidermcp/scout                     # any platform, needs Node.js/npm
+curl -fsSL https://glidermcp.com/install.sh | sh    # Linux/macOS, installs to ~/.local/bin
+brew install glidermcp/tap/scout                    # macOS/Linux
 ```
 
-The install script does not edit `PATH`. If `~/.local/bin` is not already on it, add it, or point at the binary with `SCOUT_BINARY_PATH`. With Scout installed globally you can also swap the bundled config to `"command": "scout"` with no args. Turn the delegation off with `--no-scout` or `GLIDERMCP_NO_SCOUT=1`.
+The bundled MCP config starts Scout over stdio with `"command": "scout"` and no args, so it indexes the directory the agent was started in. Pass `--root <dir>` if you need to point it somewhere else.
+
+## Why a real binary and not `npx`
+
+An `npx -y @glidermcp/scout` entry runs Scout fine on its own, but it leaves no `scout` binary on `PATH` - and `PATH` is how Glider and TGlider discover Scout to delegate `search_text` to it. With Scout reachable only through `npx` you get Scout's `find` tool and nothing else: Glider's `search_text` silently stays on loaded C# documents instead of covering every file under its solution root in any language, and TGlider's `search_text` fails outright with a `scout_not_installed` hint.
+
+A global install also keeps one Scout version in play. An `npx` entry resolves the latest published version on each start, which can drift from whatever binary Glider federates to.
+
+The install script does not edit `PATH`. If `~/.local/bin` is not already on it, add it, or point at the binary with `SCOUT_BINARY_PATH`. Turn the delegation off with `--no-scout` or `GLIDERMCP_NO_SCOUT=1`.


### PR DESCRIPTION
## Problem

The scout plugin shipped `npx -y @glidermcp/scout`. That runs Scout fine on its own, but it leaves no `scout` binary on `PATH` — and `PATH` is exactly how Glider and TGlider discover Scout to delegate `search_text` to it.

So a customer installing `glidermcp@glidermcp` + `scout@glidermcp` from the marketplace got Scout's own `find` tool while **both delegations were silently disabled**:

- Glider's `search_text` stayed on loaded C# documents instead of covering every file under its solution root in any language, reporting `data.backend: "workspace"` with no indication anything was wrong.
- TGlider's `search_text` failed outright with `scout_not_installed` — with a working Scout in the same session.

Glider's own locator documents this exclusion:

> `ScoutLocator.InstallHints` — "Commands that leave a scout binary on PATH. An `npx -y @glidermcp/scout` MCP entry does not, so it is deliberately absent here."

All three READMEs in this repo already told users to `npm install -g @glidermcp/scout`. Only the shipped config disagreed.

## Change

Switch the scout plugin (Claude + Codex) and both direct-config templates to `"command": "scout"` with no args, matching how the `glidermcp` and `glider-trace` plugins already assume a global `dotnet tool` install. Prerequisites promoted from an aside to a stated requirement in the root README, `install/README.md`, and `plugins/scout/README.md`.

`tglider` stays on `npx` — nothing federates to it.

## Trade-off

A missing binary now fails loudly at startup with a one-line fix, instead of quietly degrading search coverage in a way the customer cannot see. It also keeps one Scout version in play: an `npx` entry resolves latest on every start and can drift from whatever binary Glider federates to (observed locally: global `scout` 0.3.0 vs npx-resolved 0.6.0).

## Validation

All five JSON files re-parsed. This repo has no CI workflows, so nothing else validates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)